### PR TITLE
Fix conversion history request content-type

### DIFF
--- a/Slack.NetStandard.Tests/WebApiTests_Conversations.cs
+++ b/Slack.NetStandard.Tests/WebApiTests_Conversations.cs
@@ -54,11 +54,11 @@ namespace Slack.NetStandard.Tests
                 Channel= "C1234567890",
                 Latest = "1234567890.123456"
             };
-            await Utility.AssertWebApi(c => c.Conversations.History(request),
-                "conversations.history", "Web_ConversationsHistory.json", j =>
+            await Utility.AssertEncodedWebApi(c => c.Conversations.History(request),
+                "conversations.history", "Web_ConversationsHistory.json", nvc =>
                 {
-                    Assert.Equal("C1234567890", j.Value<string>("channel"));
-                    Assert.Equal("1234567890.123456",j.Value<string>("latest"));
+                    Assert.Equal("C1234567890", nvc["channel"]);
+                    Assert.Equal("1234567890.123456", nvc["latest"]);
                 });
         }
 

--- a/Slack.NetStandard/WebApi/ConversationsApi.cs
+++ b/Slack.NetStandard/WebApi/ConversationsApi.cs
@@ -52,7 +52,7 @@ namespace Slack.NetStandard.WebApi
 
         public Task<ConversationHistoryResponse> History(ConversationHistoryRequest request)
         {
-            return _client.MakeJsonCall<ConversationHistoryRequest, ConversationHistoryResponse>(
+            return _client.MakeUrlEncodedCall<ConversationHistoryResponse>(
                 "conversations.history", request);
         }
 


### PR DESCRIPTION
The content type required by conversations.history is `application/x-www-form-urlencoded` .

[conversations.history method | Slack](https://api.slack.com/methods/conversations.history)