### PR TITLE
Fix conversion list request content-type

### DIFF
--- a/Slack.NetStandard.Tests/WebApiTests_Conversations.cs
+++ b/Slack.NetStandard.Tests/WebApiTests_Conversations.cs
@@ -123,18 +123,18 @@ namespace Slack.NetStandard.Tests
             var request = new ConversationListRequest
             {
                 Cursor = "ABCDEF",
-                ExcludeArchived=true,
-                Types="private_channel",
-                Limit=10
+                ExcludeArchived = true,
+                Types = "private_channel",
+                Limit = 10
             };
-            await Utility.AssertWebApi(c => c.Conversations.List(request), "conversations.list",
+            await Utility.AssertEncodedWebApi(c => c.Conversations.List(request), "conversations.list",
                 "Web_ConversationsList.json",
-                j =>
+                nvc =>
                 {
-                    Assert.Equal("ABCDEF",j.Value<string>("cursor"));
-                    Assert.Equal(10,j.Value<int>("limit"));
-                    Assert.True(j.Value<bool>("exclude_archived"));
-                    Assert.Equal("private_channel",j.Value<string>("types"));
+                    Assert.Equal("ABCDEF", nvc["cursor"]);
+                    Assert.Equal(10.ToString(), nvc["limit"]);
+                    Assert.Equal("true", nvc["exclude_archived"]);
+                    Assert.Equal("private_channel", nvc["types"]);
                 });
         }
 

--- a/Slack.NetStandard/WebApi/ConversationsApi.cs
+++ b/Slack.NetStandard/WebApi/ConversationsApi.cs
@@ -120,7 +120,7 @@ namespace Slack.NetStandard.WebApi
 
         public Task<ChannelListResponse> List(ConversationListRequest request)
         {
-            return _client.MakeJsonCall<ConversationListRequest, ChannelListResponse>("conversations.list", request);
+            return _client.MakeUrlEncodedCall<ChannelListResponse>("conversations.list", request);
         }
 
         public Task<ConversationMembersResponse> Members(string channel)


### PR DESCRIPTION
The content type required by conversations.list `application/x-www-form-urlencoded` .

[conversations.list method | Slack](https://api.slack.com/methods/conversations.list)

relate https://github.com/stoiveyp/Slack.NetStandard/pull/15 .