### PR TITLE
Update UpdateMessageRequest to have a Blocks list

### DIFF
--- a/Slack.NetStandard/WebApi/Chat/UpdateMessageRequest.cs
+++ b/Slack.NetStandard/WebApi/Chat/UpdateMessageRequest.cs
@@ -22,7 +22,7 @@ namespace Slack.NetStandard.WebApi.Chat
         public string Text { get; set; }
 
         [JsonProperty("blocks", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<IMessageBlock> Blocks { get; set; }
+        public IList<IMessageBlock> Blocks { get; set; } = new List<IMessageBlock>();
 
         [JsonProperty("link_names", NullValueHandling = NullValueHandling.Ignore)]
         public bool? LinkNames { get; set; }


### PR DESCRIPTION
`PostMessageRequest` has `Blocks` initialized to a list so it can be easily added to through `RequestMessageBase`. `UpdateMessageRequest` doesn't.

Another option could be do inherit from `MessageRequestBase` but I guess not all properties are shared.