### PR TITLE
Fix method name on UpdateMessage

### DIFF
--- a/Slack.NetStandard/WebApi/ChatApi.cs
+++ b/Slack.NetStandard/WebApi/ChatApi.cs
@@ -61,7 +61,7 @@ namespace Slack.NetStandard.WebApi
 
         public Task<UpdateMessageResponse> Update(UpdateMessageRequest request)
         {
-            return _client.MakeJsonCall<UpdateMessageRequest, UpdateMessageResponse>("chat.updateMessage", request);
+            return _client.MakeJsonCall<UpdateMessageRequest, UpdateMessageResponse>("chat.update", request);
         }
     }
 }


### PR DESCRIPTION
The correct method is `chat.update`, not `chat.updateMessage`.

Docs: https://api.slack.com/methods/chat.update