### PR TITLE
Add selected user to the element value to support returned state for the select user controls

### DIFF
--- a/Slack.NetStandard.Tests/Examples/ViewSubmissionPayload.json
+++ b/Slack.NetStandard.Tests/Examples/ViewSubmissionPayload.json
@@ -39,6 +39,12 @@
             "type": "plain_text_input",
             "value": "This is my example inputted value"
           }
+        },
+        "user-select": {
+          "select-user": {
+            "type": "users_select",
+            "selected_user": "U12345678"
+          }
         }
       }
     },

--- a/Slack.NetStandard.Tests/InteractionTests.cs
+++ b/Slack.NetStandard.Tests/InteractionTests.cs
@@ -1,5 +1,6 @@
 ﻿using Slack.NetStandard.Interaction;
 using Slack.NetStandard.Messages.Elements;
+using System.Linq;
 using Xunit;
 
 namespace Slack.NetStandard.Tests
@@ -15,7 +16,11 @@ namespace Slack.NetStandard.Tests
         [Fact]
         public void ViewSubmissionPayload()
         {
-            Assert.Null(Utility.AssertSubType<InteractionPayload,ViewSubmissionPayload>("ViewSubmissionPayload.json").OtherFields);
+            var viewSubmissionPayload = Utility.AssertSubType<InteractionPayload, ViewSubmissionPayload>("ViewSubmissionPayload.json");
+
+            Assert.Null(viewSubmissionPayload.OtherFields);
+            Assert.All(viewSubmissionPayload.View.State.Values.SelectMany(v => v.Value.Values),
+                elementValue => Assert.Null(elementValue.OtherFields));
         }
 
         [Fact]

--- a/Slack.NetStandard/Objects/ElementValue.cs
+++ b/Slack.NetStandard/Objects/ElementValue.cs
@@ -15,6 +15,9 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("selected_option",NullValueHandling = NullValueHandling.Ignore)]
         public IOption SelectedOption { get; set; }
 
+        [JsonProperty("selected_user",NullValueHandling = NullValueHandling.Ignore)]
+        public string SelectedUser { get; set; }
+
         [JsonExtensionData]
         public Dictionary<string, object> OtherFields { get; set; }
     }


### PR DESCRIPTION
This change will add a new "SelectedUser" property to the ElementValue object. This will ensure that the the view submission payload can correctly handle selected values from "user select" controls.