### PR TITLE
Update Epoch to be based off DateTime.UtcNow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ var token = await OAuthV2Builder.Exchange(code,clientId,clientSecret);
 using Slack.NetStandard;
 
 var verifier = new RequestVerifier(signingSecret);
-var verified = Verifier.Verify(request.Headers[RequestVerifier.SignatureHeaderName], long.Parse(request.Headers[RequestVerifier.TimestampHeaderName]), request.Body);
+var verified = verifier.Verify(request.Headers[RequestVerifier.SignatureHeaderName], long.Parse(request.Headers[RequestVerifier.TimestampHeaderName]), request.Body);
 ```
 
 ## Receive/Respond to a slash command payload

--- a/Slack.NetStandard/Epoch.cs
+++ b/Slack.NetStandard/Epoch.cs
@@ -21,7 +21,7 @@ namespace Slack.NetStandard
             return Current - epoch <= duration.TotalSeconds;
         }
 
-        public static long Current => (long)DateTime.Now.Subtract(Base).TotalSeconds;
-        private static readonly DateTime Base = new DateTime(1970, 1, 1, 0, 0, 0, 0);
+        public static long Current => (long)DateTime.UtcNow.Subtract(Base).TotalSeconds;
+        private static readonly DateTime Base = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
     }
 }


### PR DESCRIPTION
I was trying out the RequestVerifier for my slack slash command handler and noticed that it would never come back as verified when using the `Verify()` method but if I compared the results of `RequestVerifier.GenerateSignature()` with the header value then they matched. It seems the issue is that since the UK is now in BST time using `DateTime.Now` instead of `DateTime.UtcNow` causes `.Verify()` to always return false since the timestamp isn't within the allowed time period.

I have also fixed a very minor typo on the README file.