### PR TITLE
Add dispatch_action_config (et al) to plain_text_input

### DIFF
--- a/Slack.NetStandard.Tests/BlockTests.cs
+++ b/Slack.NetStandard.Tests/BlockTests.cs
@@ -70,5 +70,25 @@ namespace Slack.NetStandard.Tests
             Assert.Null(optionGroup.AsOption());
             Assert.NotNull(optionGroup.AsOptionGroup());
         }
+
+        [Fact]
+        public void PlainTextInputElementSupportsDispatchConfig()
+        {
+            var expected = new JObject(
+                new JProperty("type", "plain_text_input"),
+                new JProperty("dispatch_action_config", new JObject(
+                    new JProperty("trigger_actions_on", new JArray("on_enter_pressed"))
+                    )
+                )
+			);
+            var actual = new PlainTextInput() {
+                DispatchActionConfig = new DispatchActionConfig(new ActionTrigger[] { ActionTrigger.OnEnterPressed })
+            };
+
+            Assert.True(JToken.DeepEquals(JObject.FromObject(actual), expected));
+
+            var result = JsonConvert.DeserializeObject<PlainTextInput>(expected.ToString());
+            Assert.Equal(ActionTrigger.OnEnterPressed, result.DispatchActionConfig.TriggerActionsOn[0]);
+        }
     }
 }

--- a/Slack.NetStandard/Messages/Elements/ActionTrigger.cs
+++ b/Slack.NetStandard/Messages/Elements/ActionTrigger.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace Slack.NetStandard.Messages.Elements
+{
+    public enum ActionTrigger
+    {
+        [EnumMember(Value = "on_enter_pressed")]
+        OnEnterPressed,
+        [EnumMember(Value = "on_character_entered")]
+        OnCharacterEntered
+    }
+}

--- a/Slack.NetStandard/Messages/Elements/DispatchActionConfig.cs
+++ b/Slack.NetStandard/Messages/Elements/DispatchActionConfig.cs
@@ -5,6 +5,8 @@ namespace Slack.NetStandard.Messages.Elements
 {
     public class DispatchActionConfig
     {
+        public DispatchActionConfig(){}
+
         public DispatchActionConfig(ActionTrigger[] triggers)
         {
             TriggerActionsOn = triggers;

--- a/Slack.NetStandard/Messages/Elements/DispatchActionConfig.cs
+++ b/Slack.NetStandard/Messages/Elements/DispatchActionConfig.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Slack.NetStandard.Messages.Elements
+{
+    public class DispatchActionConfig
+    {
+        public DispatchActionConfig(ActionTrigger[] triggers)
+        {
+            TriggerActionsOn = triggers;
+        }
+
+        [JsonProperty("trigger_actions_on", NullValueHandling = NullValueHandling.Ignore, ItemConverterType = typeof(StringEnumConverter))]
+        public ActionTrigger[] TriggerActionsOn { get; set; }
+    }
+}

--- a/Slack.NetStandard/Messages/Elements/PlainTextInput.cs
+++ b/Slack.NetStandard/Messages/Elements/PlainTextInput.cs
@@ -40,5 +40,8 @@ namespace Slack.NetStandard.Messages.Elements
 
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
+
+        [JsonProperty("dispatch_action_config", NullValueHandling = NullValueHandling.Ignore)]
+        public DispatchActionConfig DispatchActionConfig { get; set; }
     }
 }


### PR DESCRIPTION
This commit introduces support for configuring the
[`dispatch_action_config`] and its `trigger_actions_on` member to input
block elements that contain a [`plain_text_input`].

[`dispatch_action_config`]: https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config
[`plain_text_input`]: https://api.slack.com/reference/block-kit/block-elements#input