### PR TITLE
Add support for delete_original in InteractionMessage

### DIFF
--- a/Slack.NetStandard/Interaction/InteractionMessage.cs
+++ b/Slack.NetStandard/Interaction/InteractionMessage.cs
@@ -31,6 +31,9 @@ namespace Slack.NetStandard.Interaction
 
         [JsonProperty("replace_original",NullValueHandling = NullValueHandling.Ignore)]
         public bool? ReplaceOriginal { get; set; }
+        
+        [JsonProperty("delete_original",NullValueHandling = NullValueHandling.Ignore)]
+        public bool? DeleteOriginal { get; set; }
 
         public async Task<WebApiResponse> Send(string responseUrl, HttpClient client = null)
         {


### PR DESCRIPTION
This will delete the original message and then post a new one.
`replace_original` doesn't honor the response_type of the new message.
Deleting the original is the only way I've been able to work around
this.