### PR TITLE
update "expires_in" json property in AccessTokenInfo and AuthedUser.

### DIFF
--- a/Slack.NetStandard.Tests/Examples/AccessTokenInformation.json
+++ b/Slack.NetStandard.Tests/Examples/AccessTokenInformation.json
@@ -5,6 +5,7 @@
   "scope": "commands,incoming-webhook",
   "bot_user_id": "U0KRQLJ9H",
   "app_id": "A0KRD7HC3",
+  "expires_in": 43200,
   "team": {
     "name": "Slack Softball Team",
     "id": "T9TK3CUKW"
@@ -17,6 +18,7 @@
     "id": "U1234",
     "scope": "chat:write",
     "access_token": "xoxp-1234",
+    "expires_in": 43200,
     "token_type": "user"
   }
 }

--- a/Slack.NetStandard.Tests/OauthTests.cs
+++ b/Slack.NetStandard.Tests/OauthTests.cs
@@ -20,6 +20,8 @@ namespace Slack.NetStandard.Tests
             Assert.NotNull(ati.AuthedUser);
             Assert.Equal("commands,incoming-webhook", ati.Scope);
             Assert.Equal("chat:write", ati.AuthedUser.Scope);
+            Assert.Equal(43200, ati.ExpiresIn);
+            Assert.Equal(43200, ati.AuthedUser.ExpiresIn);
         }
 
         [Fact]

--- a/Slack.NetStandard/Auth/AccessTokenInformation.cs
+++ b/Slack.NetStandard/Auth/AccessTokenInformation.cs
@@ -9,7 +9,7 @@ namespace Slack.NetStandard.Auth
         [JsonProperty("access_token",NullValueHandling = NullValueHandling.Ignore)]
         public string AccessToken { get; set; }
 
-        [JsonProperty("expiresIn",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("expires_in",NullValueHandling = NullValueHandling.Ignore)]
         public long? ExpiresIn { get; set; }
 
         [JsonProperty("refresh_token",NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Auth/AuthedUser.cs
+++ b/Slack.NetStandard/Auth/AuthedUser.cs
@@ -16,7 +16,7 @@ namespace Slack.NetStandard.Auth
         [JsonProperty("id",NullValueHandling = NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [JsonProperty("expiresIn", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("expires_in", NullValueHandling = NullValueHandling.Ignore)]
         public long? ExpiresIn { get; set; }
 
         [JsonProperty("refresh_token", NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Auth/OAuthV2Builder.cs
+++ b/Slack.NetStandard/Auth/OAuthV2Builder.cs
@@ -91,7 +91,7 @@ namespace Slack.NetStandard.Auth
         {
             var dict = new Dictionary<string, string>
             {
-                {"grant_Type", "refresh_token"},
+                {"grant_type", "refresh_token"},
                 {"refresh_token", refreshToken}
             };
             if (!string.IsNullOrWhiteSpace(redirectUri))


### PR DESCRIPTION
Fix "grant_type" typo in OAuthV2Builder

Please refer to the slack documentation. The json property is "expires_in" instead of "expiresIn".

Without this fix the c# int? ExpiresIn property is always null

https://api.slack.com/methods/oauth.v2.access#:~:text=1234%22%2C%0A%20%20%20%20%20%20%20%20%22token_type%22%3A%20%22user%22%0A%20%20%20%20%7D%0A%7D-,Alternate%20response,-Successful%20token%20request

ps, I would've thought it's not case sensitive myself, but turns out the call doesn't work with "grant_Type", but does with  "grant_type" 