### PR TITLE
:bug: Add missing bot_id property to auth.test response object

### DIFF
--- a/Slack.NetStandard.Tests/Examples/Web_AuthTest.json
+++ b/Slack.NetStandard.Tests/Examples/Web_AuthTest.json
@@ -4,5 +4,6 @@
   "team": "Subarachnoid Workspace",
   "user": "grace",
   "team_id": "T12345678",
-  "user_id": "W12345678"
+  "user_id": "W12345678",
+  "bot_id": "BZYBOTHED"
 }

--- a/Slack.NetStandard/WebApi/Auth/TestResponse.cs
+++ b/Slack.NetStandard/WebApi/Auth/TestResponse.cs
@@ -18,5 +18,8 @@ namespace Slack.NetStandard.WebApi.Auth
 
         [JsonProperty("user_id",NullValueHandling = NullValueHandling.Ignore)]
         public string UserId { get; set; }
+
+        [JsonProperty("bot_id",NullValueHandling = NullValueHandling.Ignore)]
+        public string BotId { get; set; }
     }
 }


### PR DESCRIPTION
The `auth.test` method can return a `bot_id` parameter if the token used was a bot token as opposed to a user token. This property was missing from the `TestResponse` object.