### PR TITLE
Fix file share and revoke method names

### DIFF
--- a/Slack.NetStandard.Tests/WebApiTests_Files.cs
+++ b/Slack.NetStandard.Tests/WebApiTests_Files.cs
@@ -41,14 +41,14 @@ namespace Slack.NetStandard.Tests
         [Fact]
         public async Task Files_RevokePublicUrl()
         {
-            await Utility.AssertEncodedWebApi(c => c.Files.RevokePublicUrl("F1234567890"), "files.revokePublicUrl",
+            await Utility.AssertEncodedWebApi(c => c.Files.RevokePublicUrl("F1234567890"), "files.revokePublicURL",
                 "Web_FilesInfo.json", nvc => Assert.Equal("F1234567890", nvc["file"]));
         }
 
         [Fact]
         public async Task Files_SharedPublicUrl()
         {
-            await Utility.AssertEncodedWebApi(c => c.Files.SharedPublicUrl("F1234567890"), "files.sharedPublicUrl",
+            await Utility.AssertEncodedWebApi(c => c.Files.SharedPublicUrl("F1234567890"), "files.sharedPublicURL",
                 "Web_FilesInfo.json", nvc => Assert.Equal("F1234567890", nvc["file"]));
         }
 

--- a/Slack.NetStandard/WebApi/FilesApi.cs
+++ b/Slack.NetStandard/WebApi/FilesApi.cs
@@ -32,12 +32,12 @@ namespace Slack.NetStandard.WebApi
 
         public Task<FileResponse> RevokePublicUrl(string file)
         {
-            return _client.MakeUrlEncodedCall<FileResponse>("files.revokePublicUrl", new Dictionary<string, string> { { "file", file } });
+            return _client.MakeUrlEncodedCall<FileResponse>("files.revokePublicURL", new Dictionary<string, string> { { "file", file } });
         }
 
         public Task<FileResponse> SharedPublicUrl(string file)
         {
-            return _client.MakeUrlEncodedCall<FileResponse>("files.sharedPublicUrl", new Dictionary<string, string> { { "file", file } });
+            return _client.MakeUrlEncodedCall<FileResponse>("files.sharedPublicURL", new Dictionary<string, string> { { "file", file } });
         }
 
         public Task<FileResponse> Upload(FileUploadRequest request)


### PR DESCRIPTION
I received an error from Slack when trying to share a file I had
uploaded:

"unknown_method"

I updated the following:
files.sharedPublicURL instead of files.sharedPublicUrl
files.revokePublicURL instead of files.revokePublicUrl

https://api.slack.com/methods/files.sharedPublicURL
https://api.slack.com/methods/files.revokePublicURL