### PR TITLE
V4 - Update to use lists for all request calls/objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var view = new View
     Title = "Create New Story",
     Close = "Cancel",
     Submit = "Submit",
-    Blocks = new IMessageBlock[]
+    Blocks = new List<IMessageBlock>
     {
        new Section{Text = new PlainText("Only title is required")}
     }

--- a/Slack.NetStandard.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Slack.NetStandard.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,3 @@
+﻿; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+

--- a/Slack.NetStandard.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Slack.NetStandard.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,10 @@
+﻿; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+SlackNetStandardMessageConstructorAnalyzer | CodingStandard | Warning | MessageConstructors
+SlackNetStandardNewList | CodingStandard | Warning | ListUsageChecks
+SlackNetStandardShouldSerialize | CodingStandard | Warning | ListUsageChecks

--- a/Slack.NetStandard.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Slack.NetStandard.Analyzers/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 SlackNetStandardMessageConstructorAnalyzer | CodingStandard | Warning | MessageConstructors
 SlackNetStandardNewList | CodingStandard | Warning | ListUsageChecks
 SlackNetStandardShouldSerialize | CodingStandard | Warning | ListUsageChecks
+SlackNetStandardValidArray | CodingStandard | Warning | ValidArrayUseAnalyzer

--- a/Slack.NetStandard.Analyzers/ArrayPropertyToListFix.cs
+++ b/Slack.NetStandard.Analyzers/ArrayPropertyToListFix.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Slack.NetStandard.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ArrayPropertyToListFix)), Shared]
+    public class ArrayPropertyToListFix:CodeFixProvider
+    {
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root =
+                await context.Document.GetSyntaxRootAsync(context.CancellationToken)
+                    .ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Find the invocation expression identified by the diagnostic.
+            var invocationExpr =
+                root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf()
+                    .OfType<PropertyDeclarationSyntax>().First();
+
+            context.RegisterCodeFix(
+                CodeAction.Create(Resources.InvalidArrayFixTitle, c =>
+                    ConvertToList(context.Document, invocationExpr, c), equivalenceKey: nameof(Resources.InvalidArrayFixTitle)), diagnostic);
+        }
+
+        private async Task<Document> ConvertToList(Document doc, PropertyDeclarationSyntax prop, CancellationToken cancellationToken)
+        {
+            var oldRoot = (CompilationUnitSyntax)await doc.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            
+
+            if (oldRoot == null)
+            {
+                return doc;
+            }
+
+            
+            var listType = ((ArrayTypeSyntax)prop.Type).ElementType;
+            var newProp = prop.WithType(
+                SyntaxFactory.GenericName("IList")
+                    .WithTypeArgumentList(SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(listType)))
+                );
+
+            var newRoot = oldRoot.ReplaceNode(prop, newProp);
+
+            if (!oldRoot.Usings.Select(us => us.Name)
+                    .OfType<QualifiedNameSyntax>()
+                    .Any(us => us.Left is QualifiedNameSyntax left
+                               && left.Left is IdentifierNameSyntax nl && nl.Identifier.Text == "System" 
+                               && left.Right is IdentifierNameSyntax nr && nr.Identifier.Text == "Collections" 
+                               && us.Right is IdentifierNameSyntax right && right.Identifier.Text == "Generic"))
+            {
+                var name = SyntaxFactory.QualifiedName(SyntaxFactory.QualifiedName(SyntaxFactory.IdentifierName("System"),SyntaxFactory.IdentifierName("Collections")),
+                    SyntaxFactory.IdentifierName("Generic"));
+                return doc.WithSyntaxRoot(newRoot.AddUsings(SyntaxFactory.UsingDirective(name)));
+            }
+
+            return doc.WithSyntaxRoot(newRoot);
+        }
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(ValidArrayUseAnalyzer.ValidArrayDiagnosticId);
+    }
+}

--- a/Slack.NetStandard.Analyzers/ListUsageChecks.cs
+++ b/Slack.NetStandard.Analyzers/ListUsageChecks.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Slack.NetStandard.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ListUsageChecks : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "SlackNetStandardListUsageAnalyzer";
+
+        public static void CheckProperty(SymbolAnalysisContext symbolAnalysis)
+        {
+            var node = (IPropertySymbol)symbolAnalysis.Symbol;
+            var propType = node.Type;
+
+            if (!propType.Name.Contains("List"))
+            {
+                //only want list properties
+                return;
+            }
+
+            var attributes = node.GetAttributes();
+            if (attributes.IsEmpty || !attributes.Any(ad => ad.AttributeClass.Name == "JsonPropertyAttribute"))
+            {
+                //Only care about lists involved in serialization
+                return;
+            }
+
+            if (!(node.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is PropertyDeclarationSyntax syntax))
+            {
+                return;
+            }
+
+            if (syntax.Initializer == null)
+            {
+                var notNewedList = Diagnostic.Create(NewedListRule, node.Locations[0], node.Name);
+                symbolAnalysis.ReportDiagnostic(notNewedList);
+                return;
+            }
+
+            var methods = node.ContainingType.GetMembers().OfType<IMethodSymbol>().FirstOrDefault(ims => ims.Name == "ShouldSerialize" + node.Name);
+
+            if (methods != null)
+            {
+                var noShouldSerializeMethod = Diagnostic.Create(ShouldSerializeRule, node.Locations[0], node.Name);
+                symbolAnalysis.ReportDiagnostic(noShouldSerializeMethod);
+            }
+        }
+
+        private static readonly LocalizableString ListNewTitle = new LocalizableResourceString(nameof(Resources.ListNewTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString ListNewMessageFormat = new LocalizableResourceString(nameof(Resources.ListNewMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString ListNewDescription = new LocalizableResourceString(nameof(Resources.ListNewDescription), Resources.ResourceManager, typeof(Resources));
+
+        private static readonly LocalizableString ListShouldSerializeTitle = new LocalizableResourceString(nameof(Resources.ListShouldSerializeTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString ListShouldSerializeMessageFormat = new LocalizableResourceString(nameof(Resources.ListShouldSerializeMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString ListShouldSerializeDescription = new LocalizableResourceString(nameof(Resources.ListShouldSerializeDescription), Resources.ResourceManager, typeof(Resources));
+
+        private const string Category = "CodingStandard";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(NewedListRule, ShouldSerializeRule);
+
+        private static readonly DiagnosticDescriptor NewedListRule = new DiagnosticDescriptor(DiagnosticId, ListNewTitle, ListNewMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: ListNewDescription);
+        private static readonly DiagnosticDescriptor ShouldSerializeRule = new DiagnosticDescriptor(DiagnosticId, ListShouldSerializeTitle, ListShouldSerializeMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: ListShouldSerializeDescription);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(CheckProperty, SymbolKind.Property);
+        }
+    }
+}

--- a/Slack.NetStandard.Analyzers/ListUsageChecks.cs
+++ b/Slack.NetStandard.Analyzers/ListUsageChecks.cs
@@ -44,7 +44,7 @@ namespace Slack.NetStandard.Analyzers
 
             var methods = node.ContainingType.GetMembers().OfType<IMethodSymbol>().FirstOrDefault(ims => ims.Name == "ShouldSerialize" + node.Name);
 
-            if (methods != null)
+            if (methods == null)
             {
                 var noShouldSerializeMethod = Diagnostic.Create(ShouldSerializeRule, node.Locations[0], node.Name);
                 symbolAnalysis.ReportDiagnostic(noShouldSerializeMethod);

--- a/Slack.NetStandard.Analyzers/ListUsageChecks.cs
+++ b/Slack.NetStandard.Analyzers/ListUsageChecks.cs
@@ -10,7 +10,8 @@ namespace Slack.NetStandard.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class ListUsageChecks : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = "SlackNetStandardListUsageAnalyzer";
+        public const string NewListDiagnosticId = "SlackNetStandardNewList";
+        public const string ShouldSerializeDiagnosticId = "SlackNetStandardShouldSerialize";
 
         public static void CheckProperty(SymbolAnalysisContext symbolAnalysis)
         {
@@ -63,8 +64,8 @@ namespace Slack.NetStandard.Analyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(NewedListRule, ShouldSerializeRule);
 
-        private static readonly DiagnosticDescriptor NewedListRule = new DiagnosticDescriptor(DiagnosticId, ListNewTitle, ListNewMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: ListNewDescription);
-        private static readonly DiagnosticDescriptor ShouldSerializeRule = new DiagnosticDescriptor(DiagnosticId, ListShouldSerializeTitle, ListShouldSerializeMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: ListShouldSerializeDescription);
+        private static readonly DiagnosticDescriptor NewedListRule = new DiagnosticDescriptor(NewListDiagnosticId, ListNewTitle, ListNewMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: ListNewDescription);
+        private static readonly DiagnosticDescriptor ShouldSerializeRule = new DiagnosticDescriptor(ShouldSerializeDiagnosticId, ListShouldSerializeTitle, ListShouldSerializeMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: ListShouldSerializeDescription);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/Slack.NetStandard.Analyzers/ListUsageFix.cs
+++ b/Slack.NetStandard.Analyzers/ListUsageFix.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/Slack.NetStandard.Analyzers/ListUsageFix.cs
+++ b/Slack.NetStandard.Analyzers/ListUsageFix.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Slack.NetStandard.Analyzers
+{
+    //https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ListUsageFix)), Shared]
+    public class ListUsageFix:CodeFixProvider
+    {
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root =
+                await context.Document.GetSyntaxRootAsync(context.CancellationToken)
+                    .ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Find the invocation expression identified by the diagnostic.
+            var invocationExpr =
+                root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf()
+                    .OfType<PropertyDeclarationSyntax>().First();
+
+            // Register a code action that will invoke the fix.
+            context.RegisterCodeFix(
+                CodeAction.Create(Resources.ListNewFixTitle, c =>
+                    NewUpList(context.Document, invocationExpr, c), equivalenceKey: nameof(Resources.ListNewFixTitle)), diagnostic);
+        }
+
+        private async Task<Document> NewUpList(Document contextDocument, PropertyDeclarationSyntax invocationExpr,
+            CancellationToken cancellationToken)
+        {
+
+            var genericType = (GenericNameSyntax)invocationExpr.Type;
+            var listType = genericType.TypeArgumentList.Arguments.First();
+
+            ExpressionSyntax newType = null;
+
+            if (genericType.Identifier.Text.Contains("IList"))
+            {
+                newType = SyntaxFactory.ObjectCreationExpression(
+                            SyntaxFactory.GenericName("List").WithTypeArgumentList(
+                                SyntaxFactory.TypeArgumentList(
+                                    SyntaxFactory.SeparatedList<TypeSyntax>(
+                                        new SyntaxNodeOrToken[] { listType }))))
+                        .WithArgumentList(SyntaxFactory.ArgumentList());
+            }
+            else
+            {
+                newType = SyntaxFactory.ImplicitObjectCreationExpression();
+            }
+
+
+            var newToken =
+                invocationExpr.WithInitializer(
+                    SyntaxFactory.EqualsValueClause(newType))
+                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                    .WithTrailingTrivia(invocationExpr.GetTrailingTrivia());
+
+            SyntaxNode oldRoot = await contextDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            SyntaxNode newRoot = oldRoot.ReplaceNode(invocationExpr,newToken);
+
+            // Return document with transformed tree.
+            return contextDocument.WithSyntaxRoot(newRoot);
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ListUsageChecks.NewListDiagnosticId);
+    }
+}

--- a/Slack.NetStandard.Analyzers/MessageConstructors.cs
+++ b/Slack.NetStandard.Analyzers/MessageConstructors.cs
@@ -12,9 +12,9 @@ using System.Threading;
 namespace Slack.NetStandard.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SlackNetStandardAnalyzersAnalyzer : DiagnosticAnalyzer
+    public class MessageConstructors : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = "SlackNetStandardAnalyzers";
+        public const string DiagnosticId = "SlackNetStandardMessageConstructorAnalyzer";
 
         // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
         // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
@@ -26,12 +26,12 @@ namespace Slack.NetStandard.Analyzers
         private static readonly LocalizableString ElementTypeMessageFormat = new LocalizableResourceString(nameof(Resources.ElementTypeMessageFormat), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString ElementTypeDescription = new LocalizableResourceString(nameof(Resources.ElementTypeDescription), Resources.ResourceManager, typeof(Resources));
 
-        private const string Category = "Naming";
+        private const string Category = "CodingStandard";
 
         private static readonly DiagnosticDescriptor BlockRule = new DiagnosticDescriptor(DiagnosticId, BlockTypeTitle, BlockTypeMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: BlockTypeDescription);
         private static readonly DiagnosticDescriptor ElementRule = new DiagnosticDescriptor(DiagnosticId, ElementTypeTitle, ElementTypeMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: ElementTypeDescription);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(BlockRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(BlockRule, ElementRule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/Slack.NetStandard.Analyzers/Resources.Designer.cs
+++ b/Slack.NetStandard.Analyzers/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace Slack.NetStandard.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert to list.
+        /// </summary>
+        internal static string InvalidArrayFixTitle {
+            get {
+                return ResourceManager.GetString("InvalidArrayFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All list properties must be newed in the property and have a ShouldSerialize method in case they&apos;re empty..
         /// </summary>
         internal static string ListNewDescription {

--- a/Slack.NetStandard.Analyzers/Resources.Designer.cs
+++ b/Slack.NetStandard.Analyzers/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace Slack.NetStandard.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Initialize List.
+        /// </summary>
+        internal static string ListNewFixTitle {
+            get {
+                return ResourceManager.GetString("ListNewFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to List Property &apos;{0}&apos; is not initialized.
         /// </summary>
         internal static string ListNewMessageFormat {
@@ -151,6 +160,15 @@ namespace Slack.NetStandard.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add ShouldSerialize Method.
+        /// </summary>
+        internal static string ListShouldSerializeFixTitle {
+            get {
+                return ResourceManager.GetString("ListShouldSerializeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to List Property &apos;{0}&apos; does not have a corresponding ShouldSerialize{0} method.
         /// </summary>
         internal static string ListShouldSerializeMessageFormat {
@@ -165,6 +183,33 @@ namespace Slack.NetStandard.Analyzers {
         internal static string ListShouldSerializeTitle {
             get {
                 return ResourceManager.GetString("ListShouldSerializeTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Arrays should only be used in Event API classes, responses or excluded via the AllowedArray attribute..
+        /// </summary>
+        internal static string ValidArrayDescription {
+            get {
+                return ResourceManager.GetString("ValidArrayDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Array property {0} is invalid.
+        /// </summary>
+        internal static string ValidArrayMessageFormat {
+            get {
+                return ResourceManager.GetString("ValidArrayMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Array type is not valid in this class.
+        /// </summary>
+        internal static string ValidArrayTitle {
+            get {
+                return ResourceManager.GetString("ValidArrayTitle", resourceCulture);
             }
         }
     }

--- a/Slack.NetStandard.Analyzers/Resources.Designer.cs
+++ b/Slack.NetStandard.Analyzers/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Slack.NetStandard.Analyzers {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -61,7 +61,7 @@ namespace Slack.NetStandard.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All block types should have at least one empty and one helper constructors.
+        ///   Looks up a localized string similar to All block types should have at least one empty and one helper constructors..
         /// </summary>
         internal static string BlockTypeDescription {
             get {
@@ -88,7 +88,7 @@ namespace Slack.NetStandard.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All element types should have at least one empty and one helper constructors.
+        ///   Looks up a localized string similar to All element types should have at least one empty and one helper constructors..
         /// </summary>
         internal static string ElementTypeDescription {
             get {
@@ -111,6 +111,60 @@ namespace Slack.NetStandard.Analyzers {
         internal static string ElementTypeTitle {
             get {
                 return ResourceManager.GetString("ElementTypeTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All list properties must be newed in the property and have a ShouldSerialize method in case they&apos;re empty..
+        /// </summary>
+        internal static string ListNewDescription {
+            get {
+                return ResourceManager.GetString("ListNewDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List Property &apos;{0}&apos; is not initialized.
+        /// </summary>
+        internal static string ListNewMessageFormat {
+            get {
+                return ResourceManager.GetString("ListNewMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List property missing initializer.
+        /// </summary>
+        internal static string ListNewTitle {
+            get {
+                return ResourceManager.GetString("ListNewTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List properties should have a ShouldSerialize method in case they&apos;re empty..
+        /// </summary>
+        internal static string ListShouldSerializeDescription {
+            get {
+                return ResourceManager.GetString("ListShouldSerializeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List Property &apos;{0}&apos; does not have a corresponding ShouldSerialize{0} method.
+        /// </summary>
+        internal static string ListShouldSerializeMessageFormat {
+            get {
+                return ResourceManager.GetString("ListShouldSerializeMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List Property missing serialization method.
+        /// </summary>
+        internal static string ListShouldSerializeTitle {
+            get {
+                return ResourceManager.GetString("ListShouldSerializeTitle", resourceCulture);
             }
         }
     }

--- a/Slack.NetStandard.Analyzers/Resources.resx
+++ b/Slack.NetStandard.Analyzers/Resources.resx
@@ -138,6 +138,9 @@
   <data name="ListNewDescription" xml:space="preserve">
     <value>All list properties must be newed in the property and have a ShouldSerialize method in case they're empty.</value>
   </data>
+  <data name="ListNewFixTitle" xml:space="preserve">
+    <value>Initialize List</value>
+  </data>
   <data name="ListNewMessageFormat" xml:space="preserve">
     <value>List Property '{0}' is not initialized</value>
   </data>
@@ -147,10 +150,22 @@
   <data name="ListShouldSerializeDescription" xml:space="preserve">
     <value>List properties should have a ShouldSerialize method in case they're empty.</value>
   </data>
+  <data name="ListShouldSerializeFixTitle" xml:space="preserve">
+    <value>Add ShouldSerialize Method</value>
+  </data>
   <data name="ListShouldSerializeMessageFormat" xml:space="preserve">
     <value>List Property '{0}' does not have a corresponding ShouldSerialize{0} method</value>
   </data>
   <data name="ListShouldSerializeTitle" xml:space="preserve">
     <value>List Property missing serialization method</value>
+  </data>
+  <data name="ValidArrayDescription" xml:space="preserve">
+    <value>Arrays should only be used in Event API classes, responses or excluded via the AllowedArray attribute.</value>
+  </data>
+  <data name="ValidArrayMessageFormat" xml:space="preserve">
+    <value>Array property {0} is invalid</value>
+  </data>
+  <data name="ValidArrayTitle" xml:space="preserve">
+    <value>Array type is not valid in this class</value>
   </data>
 </root>

--- a/Slack.NetStandard.Analyzers/Resources.resx
+++ b/Slack.NetStandard.Analyzers/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="BlockTypeDescription" xml:space="preserve">
-    <value>All block types should have at least one empty and one helper constructors</value>
+    <value>All block types should have at least one empty and one helper constructors.</value>
   </data>
   <data name="BlockTypeMessageFormat" xml:space="preserve">
     <value>Block type '{0}' is missing either an empty or helper constructor</value>
@@ -127,12 +127,30 @@
     <value>Block type does not adhere to constructor rules</value>
   </data>
   <data name="ElementTypeDescription" xml:space="preserve">
-    <value>All element types should have at least one empty and one helper constructors</value>
+    <value>All element types should have at least one empty and one helper constructors.</value>
   </data>
   <data name="ElementTypeMessageFormat" xml:space="preserve">
     <value>Element type '{0}' is missing either an empty or helper constructor</value>
   </data>
   <data name="ElementTypeTitle" xml:space="preserve">
     <value>Element type does not adhere to constructor rules</value>
+  </data>
+  <data name="ListNewDescription" xml:space="preserve">
+    <value>All list properties must be newed in the property and have a ShouldSerialize method in case they're empty.</value>
+  </data>
+  <data name="ListNewMessageFormat" xml:space="preserve">
+    <value>List Property '{0}' is not initialized</value>
+  </data>
+  <data name="ListNewTitle" xml:space="preserve">
+    <value>List property missing initializer</value>
+  </data>
+  <data name="ListShouldSerializeDescription" xml:space="preserve">
+    <value>List properties should have a ShouldSerialize method in case they're empty.</value>
+  </data>
+  <data name="ListShouldSerializeMessageFormat" xml:space="preserve">
+    <value>List Property '{0}' does not have a corresponding ShouldSerialize{0} method</value>
+  </data>
+  <data name="ListShouldSerializeTitle" xml:space="preserve">
+    <value>List Property missing serialization method</value>
   </data>
 </root>

--- a/Slack.NetStandard.Analyzers/Resources.resx
+++ b/Slack.NetStandard.Analyzers/Resources.resx
@@ -168,4 +168,7 @@
   <data name="ValidArrayTitle" xml:space="preserve">
     <value>Array type is not valid in this class</value>
   </data>
+  <data name="InvalidArrayFixTitle" xml:space="preserve">
+    <value>Convert to list</value>
+  </data>
 </root>

--- a/Slack.NetStandard.Analyzers/ShouldSerializeFix.cs
+++ b/Slack.NetStandard.Analyzers/ShouldSerializeFix.cs
@@ -41,15 +41,17 @@ namespace Slack.NetStandard.Analyzers
 
         private async Task<Document> AddShouldSerialize(Document doc, PropertyDeclarationSyntax property, ClassDeclarationSyntax classType, CancellationToken cancellationToken)
         {
-            var arrowExpression = SyntaxFactory.ArrowExpressionClause(
-                SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            var anyCheck = SyntaxFactory.ConditionalAccessExpression(
                     SyntaxFactory.IdentifierName(property.Identifier.Text),
-                    SyntaxFactory.IdentifierName("Any"))));
+                    SyntaxFactory.InvocationExpression(SyntaxFactory.MemberBindingExpression(SyntaxFactory.IdentifierName("Any")))
+                    );
+
+            var nullCoalesce = SyntaxFactory.BinaryExpression(SyntaxKind.CoalesceExpression,
+                anyCheck, SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression));
 
             var newMethod = SyntaxFactory.MethodDeclaration(
                     SyntaxFactory.ParseTypeName("bool"), $"ShouldSerialize{property.Identifier.Text}")
-                .WithExpressionBody(arrowExpression)
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(nullCoalesce))
                 .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
 

--- a/Slack.NetStandard.Analyzers/ShouldSerializeFix.cs
+++ b/Slack.NetStandard.Analyzers/ShouldSerializeFix.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Slack.NetStandard.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ShouldSerializeFix)), Shared]
+    public class ShouldSerializeFix:CodeFixProvider
+    {
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root =
+                await context.Document.GetSyntaxRootAsync(context.CancellationToken)
+                    .ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Find the invocation expression identified by the diagnostic.
+            var invocationExpr =
+                root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf()
+                    .OfType<PropertyDeclarationSyntax>().First();
+            var classType = invocationExpr.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+
+            if (classType == null)
+            {
+                return;
+            }
+            // Register a code action that will invoke the fix.
+            context.RegisterCodeFix(
+                CodeAction.Create(Resources.ListShouldSerializeFixTitle, c =>
+                    AddShouldSerialize(context.Document, invocationExpr, classType, c), equivalenceKey: nameof(Resources.ListShouldSerializeFixTitle)), diagnostic);
+        }
+
+        private async Task<Document> AddShouldSerialize(Document doc, PropertyDeclarationSyntax property, ClassDeclarationSyntax classType, CancellationToken cancellationToken)
+        {
+            var arrowExpression = SyntaxFactory.ArrowExpressionClause(
+                SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(property.Identifier.Text),
+                    SyntaxFactory.IdentifierName("Any"))));
+
+            var newMethod = SyntaxFactory.MethodDeclaration(
+                    SyntaxFactory.ParseTypeName("bool"), $"ShouldSerialize{property.Identifier.Text}")
+                .WithExpressionBody(arrowExpression)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
+
+            var newClass = classType.AddMembers(newMethod);
+            var oldRoot = (CompilationUnitSyntax)await doc.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (oldRoot == null)
+            {
+                return doc;
+            }
+
+            var newRoot = oldRoot.ReplaceNode(classType, newClass);
+
+            if (!oldRoot.Usings.Select(us => us.Name)
+                    .OfType<QualifiedNameSyntax>()
+                    .Any(us => us.Left is IdentifierNameSyntax left && left.Identifier.Text == "System" && us.Right is IdentifierNameSyntax right && right.Identifier.Text == "Linq"))
+            {
+                var name = SyntaxFactory.QualifiedName(SyntaxFactory.IdentifierName("System"),
+                    SyntaxFactory.IdentifierName("Linq"));
+                return doc.WithSyntaxRoot(newRoot.AddUsings(SyntaxFactory.UsingDirective(name)));
+            }
+
+            return doc.WithSyntaxRoot(newRoot);
+        }
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(ListUsageChecks.ShouldSerializeDiagnosticId);
+    }
+}

--- a/Slack.NetStandard.Analyzers/Slack.NetStandard.Analyzers.csproj
+++ b/Slack.NetStandard.Analyzers/Slack.NetStandard.Analyzers.csproj
@@ -9,8 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Slack.NetStandard.Analyzers/Slack.NetStandard.Analyzers.csproj
+++ b/Slack.NetStandard.Analyzers/Slack.NetStandard.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Slack.NetStandard.Analyzers/ValidArrayUseAnalyzer.cs
+++ b/Slack.NetStandard.Analyzers/ValidArrayUseAnalyzer.cs
@@ -31,13 +31,13 @@ namespace Slack.NetStandard.Analyzers
                 return;
             }
 
-            if (node.ContainingType.Name.Contains("Response") || node.ContainingNamespace.Name.Contains("Slack.NetStandard.EventsApi"))
+            if (node.ContainingType.Name.Contains("Response") || HasEventsNamespace(node))
             {
                 return;
             }
 
             var attributes = node.GetAttributes();
-            if (attributes.Any(ad => ad.AttributeClass.Name == "JsonPropertyAttribute"))
+            if (attributes.Any(ad => ad.AttributeClass?.Name == "AcceptedArrayAttribute"))
             {
                 //Only care about lists involved in serialization
                 return;
@@ -45,6 +45,21 @@ namespace Slack.NetStandard.Analyzers
 
             var notNewedList = Diagnostic.Create(ValidArrayRule, node.Locations[0], node.Name);
             symbolAnalysis.ReportDiagnostic(notNewedList);
+        }
+
+        private bool HasEventsNamespace(IPropertySymbol node)
+        {
+            var ns = node.ContainingNamespace;
+            while (ns != null)
+            {
+                if (ns.Name.Contains("EventsApi"))
+                {
+                    return true;
+                }
+                ns = ns.ContainingNamespace;
+            }
+
+            return false;
         }
 
         private static readonly LocalizableString ValidArrayTitle = new LocalizableResourceString(nameof(Resources.ValidArrayTitle), Resources.ResourceManager, typeof(Resources));

--- a/Slack.NetStandard.Analyzers/ValidArrayUseAnalyzer.cs
+++ b/Slack.NetStandard.Analyzers/ValidArrayUseAnalyzer.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Slack.NetStandard.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ValidArrayUseAnalyzer:DiagnosticAnalyzer
+    {
+        public const string ValidArrayDiagnosticId = "SlackNetStandardValidArray";
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSymbolAction(CheckForValidArray, SymbolKind.Property);
+        }
+
+        private void CheckForValidArray(SymbolAnalysisContext symbolAnalysis)
+        {
+            var node = (IPropertySymbol)symbolAnalysis.Symbol;
+            var propType = node.Type;
+
+            if (propType.TypeKind != TypeKind.Array)
+            {
+                //only want list properties
+                return;
+            }
+
+            if (node.ContainingType.Name.Contains("Response") || node.ContainingNamespace.Name.Contains("Slack.NetStandard.EventsApi"))
+            {
+                return;
+            }
+
+            var attributes = node.GetAttributes();
+            if (attributes.Any(ad => ad.AttributeClass.Name == "JsonPropertyAttribute"))
+            {
+                //Only care about lists involved in serialization
+                return;
+            }
+
+            var notNewedList = Diagnostic.Create(ValidArrayRule, node.Locations[0], node.Name);
+            symbolAnalysis.ReportDiagnostic(notNewedList);
+        }
+
+        private static readonly LocalizableString ValidArrayTitle = new LocalizableResourceString(nameof(Resources.ValidArrayTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString ValidArrayMessageFormat = new LocalizableResourceString(nameof(Resources.ValidArrayMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString ValidArrayDescription = new LocalizableResourceString(nameof(Resources.ValidArrayDescription), Resources.ResourceManager, typeof(Resources));
+
+        private const string Category = "CodingStandard";
+        private static readonly DiagnosticDescriptor ValidArrayRule = new DiagnosticDescriptor(ValidArrayDiagnosticId, ValidArrayTitle, ValidArrayMessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: ValidArrayDescription);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(ValidArrayRule);
+    }
+}

--- a/Slack.NetStandard.Analyzers/ValidArrayUseAnalyzer.cs
+++ b/Slack.NetStandard.Analyzers/ValidArrayUseAnalyzer.cs
@@ -36,16 +36,17 @@ namespace Slack.NetStandard.Analyzers
                 return;
             }
 
-            var attributes = node.GetAttributes();
-            if (attributes.Any(ad => ad.AttributeClass?.Name == "AcceptedArrayAttribute"))
+            if (IsAcceptedArray(node.GetAttributes()) || IsAcceptedArray(node.ContainingType.GetAttributes()))
             {
-                //Only care about lists involved in serialization
                 return;
             }
 
             var notNewedList = Diagnostic.Create(ValidArrayRule, node.Locations[0], node.Name);
             symbolAnalysis.ReportDiagnostic(notNewedList);
         }
+
+        private bool IsAcceptedArray(ImmutableArray<AttributeData> attributes) =>
+            attributes.Any(ad => ad.AttributeClass?.Name == "AcceptedArrayAttribute");
 
         private bool HasEventsNamespace(IPropertySymbol node)
         {

--- a/Slack.NetStandard.Tests/Examples/ViewSubmissionPayload.json
+++ b/Slack.NetStandard.Tests/Examples/ViewSubmissionPayload.json
@@ -16,7 +16,6 @@
       "type": "plain_text",
       "text": "Title"
     },
-    "blocks": [],
     "private_metadata": "shhh-its-secret",
     "callback_id": "modal-with-inputs",
     "state": {

--- a/Slack.NetStandard.Tests/InteractionTests.cs
+++ b/Slack.NetStandard.Tests/InteractionTests.cs
@@ -108,10 +108,10 @@ namespace Slack.NetStandard.Tests
             Assert.Null(Utility.AssertSubType<InteractionPayload, BlockActionsPayload>("Interaction_BlockActions_Home.json", "token").OtherFields);
         }
 
-        [Fact]
-        public void InteractionErrors()
-        {
-            Utility.AssertType<InputErrors>("Interaction_InputErrors.json");
-        }
+        //[Fact]
+        //public void InteractionErrors()
+        //{
+        //    Utility.AssertType<InputErrors>("Interaction_InputErrors.json");
+        //}
     }
 }

--- a/Slack.NetStandard.Tests/OauthTests.cs
+++ b/Slack.NetStandard.Tests/OauthTests.cs
@@ -15,7 +15,7 @@ namespace Slack.NetStandard.Tests
         [Fact]
         public async Task ClientAuthCheck()
         {
-            var client = new HttpClient(new ActionHandler(async req =>
+            var client = new HttpClient(new ActionHandler(req =>
             {
                 Assert.Equal("Bearer", req.Headers.Authorization.Scheme);
                 Assert.Equal("wibble", req.Headers.Authorization.Parameter);
@@ -28,7 +28,7 @@ namespace Slack.NetStandard.Tests
         [Fact]
         public async Task ClientTokenCheck()
         {
-            var client = new HttpClient(new ActionHandler(async req =>
+            var client = new HttpClient(new ActionHandler(req =>
             {
                 Assert.Equal("Bearer", req.Headers.Authorization.Scheme);
                 Assert.Equal("test", req.Headers.Authorization.Parameter);

--- a/Slack.NetStandard.sln
+++ b/Slack.NetStandard.sln
@@ -9,7 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Slack.NetStandard.Tests", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4D7A7598-16F6-4CBF-82AD-20D1AE98FE4B}"
 	ProjectSection(SolutionItems) = preProject
-		CONTRIBUTING.md = CONTRIBUTING.md
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Slack.NetStandard.sln
+++ b/Slack.NetStandard.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28705.295
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32526.322
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Slack.NetStandard", "Slack.NetStandard\Slack.NetStandard.csproj", "{3196601E-9415-4B9D-A493-AFCF7D163D38}"
 EndProject
@@ -9,6 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Slack.NetStandard.Tests", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4D7A7598-16F6-4CBF-82AD-20D1AE98FE4B}"
 	ProjectSection(SolutionItems) = preProject
+		CONTRIBUTING.md = CONTRIBUTING.md
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Slack.NetStandard/AcceptedArrayAttribute.cs
+++ b/Slack.NetStandard/AcceptedArrayAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Slack.NetStandard
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class AcceptedArrayAttribute:Attribute
+    {
+    }
+}

--- a/Slack.NetStandard/AcceptedArrayAttribute.cs
+++ b/Slack.NetStandard/AcceptedArrayAttribute.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Slack.NetStandard
 {
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
     public class AcceptedArrayAttribute:Attribute
     {
     }

--- a/Slack.NetStandard/ApiCommon/AppRequest.cs
+++ b/Slack.NetStandard/ApiCommon/AppRequest.cs
@@ -21,7 +21,7 @@ namespace Slack.NetStandard.ApiCommon
         [JsonProperty("team", NullValueHandling = NullValueHandling.Ignore)]
         public TeamSummary Team { get; set; }
 
-        [JsonProperty("scopes", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("scopes", NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public Scope[] Scopes { get; set; }
 
         [JsonProperty("message", NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/ApiCommon/InviteRequest.cs
+++ b/Slack.NetStandard/ApiCommon/InviteRequest.cs
@@ -1,5 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 using Slack.NetStandard.Objects;
+using System.Linq;
 
 namespace Slack.NetStandard.ApiCommon
 {
@@ -14,11 +16,11 @@ namespace Slack.NetStandard.ApiCommon
         [JsonProperty("date_created",NullValueHandling = NullValueHandling.Ignore)]
         public long? DateCreated { get; set; }
 
-        [JsonProperty("requester_ids",NullValueHandling = NullValueHandling.Ignore)]
-        public string[] RequesterIds { get; set; }
+        [JsonProperty("requester_ids", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<string> RequesterIds { get; set; } = new List<string>();
 
-        [JsonProperty("channel_ids",NullValueHandling = NullValueHandling.Ignore)]
-        public string[] ChannelIds { get; set; }
+        [JsonProperty("channel_ids", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<string> ChannelIds { get; set; } = new List<string>();
 
         [JsonProperty("invite_type",NullValueHandling = NullValueHandling.Ignore)]
         public string InviteType { get; set; }
@@ -34,5 +36,8 @@ namespace Slack.NetStandard.ApiCommon
 
         [JsonProperty("team",NullValueHandling = NullValueHandling.Ignore)]
         public TeamSummary Team { get; set; }
+
+        public bool ShouldSerializeRequesterIds() => RequesterIds.Any();
+        public bool ShouldSerializeChannelIds() => ChannelIds.Any();
     }
 }

--- a/Slack.NetStandard/ApiCommon/InviteRequest.cs
+++ b/Slack.NetStandard/ApiCommon/InviteRequest.cs
@@ -37,7 +37,7 @@ namespace Slack.NetStandard.ApiCommon
         [JsonProperty("team",NullValueHandling = NullValueHandling.Ignore)]
         public TeamSummary Team { get; set; }
 
-        public bool ShouldSerializeRequesterIds() => RequesterIds.Any();
-        public bool ShouldSerializeChannelIds() => ChannelIds.Any();
+        public bool ShouldSerializeRequesterIds() => RequesterIds?.Any() ?? false;
+        public bool ShouldSerializeChannelIds() => ChannelIds?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/ApiCommon/Reaction.cs
+++ b/Slack.NetStandard/ApiCommon/Reaction.cs
@@ -10,7 +10,7 @@ namespace Slack.NetStandard.ApiCommon
         [JsonProperty("count")]
         public int Count { get; set; }
 
-        [JsonProperty("users")]
+        [JsonProperty("users"), AcceptedArray]
         public string[] Users { get; set; }
     }
 }

--- a/Slack.NetStandard/Interaction/BlockActionsPayload.cs
+++ b/Slack.NetStandard/Interaction/BlockActionsPayload.cs
@@ -18,7 +18,7 @@ namespace Slack.NetStandard.Interaction
         [JsonProperty("message", NullValueHandling = NullValueHandling.Ignore)]
         public Message Message { get; set; }
 
-        [JsonProperty("actions",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("actions",NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public PayloadAction[] Actions { get; set; }
 
         [JsonProperty("channel", NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Interaction/InputErrors.cs
+++ b/Slack.NetStandard/Interaction/InputErrors.cs
@@ -5,9 +5,9 @@ using Newtonsoft.Json;
 
 namespace Slack.NetStandard.Interaction
 {
-    public class InputErrors
-    {
-        [JsonProperty("errors")]
-        public ErrorInformation[] Errors { get; set; }
-    }
+    //public class InputErrors
+    //{
+    //    [JsonProperty("errors")]
+    //    public ErrorInformation[] Errors { get; set; }
+    //}
 }

--- a/Slack.NetStandard/Interaction/PayloadAction.cs
+++ b/Slack.NetStandard/Interaction/PayloadAction.cs
@@ -27,7 +27,7 @@ namespace Slack.NetStandard.Interaction
         [JsonProperty("selected_option", NullValueHandling = NullValueHandling.Ignore)]
         public IOption SelectedOption { get; set; }
 
-        [JsonProperty("selected_options", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("selected_options", NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public IOption[] SelectedOptions { get; set; }
 
         [JsonProperty("selected_user", NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Interaction/ViewSubmissionPayload.cs
+++ b/Slack.NetStandard/Interaction/ViewSubmissionPayload.cs
@@ -9,7 +9,7 @@ namespace Slack.NetStandard.Interaction
         [JsonProperty("view", NullValueHandling = NullValueHandling.Ignore)]
         public View View { get; set; }
 
-        [JsonProperty("response_urls",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("response_urls",NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public string[] ResponseUrls{ get; set; }
 
         [JsonProperty("workflow_step",NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/JsonConverters/ContextElementConverter.cs
+++ b/Slack.NetStandard/JsonConverters/ContextElementConverter.cs
@@ -34,7 +34,7 @@ namespace Slack.NetStandard.JsonConverters
             return target;
         }
 
-        public static Dictionary<string, Type> IMessageElementLookup = new Dictionary<string, Type>
+        public static Dictionary<string, Type> IMessageElementLookup = new()
         {
             {ToEnumString(TextType.PlainText), typeof(PlainText)},
             {ToEnumString(TextType.Markdown), typeof(MarkdownText)},

--- a/Slack.NetStandard/Messages/Attachment.cs
+++ b/Slack.NetStandard/Messages/Attachment.cs
@@ -10,7 +10,7 @@ namespace Slack.NetStandard.Messages
     public class Attachment
     {
         [JsonProperty("blocks", NullValueHandling = NullValueHandling.Ignore)]
-        public List<IMessageBlock> Blocks { get; set; } = new List<IMessageBlock>();
+        public List<IMessageBlock> Blocks { get; set; } = new ();
 
         [JsonProperty("color",NullValueHandling = NullValueHandling.Ignore)]
         public string Color { get; set; }
@@ -40,7 +40,7 @@ namespace Slack.NetStandard.Messages
         public string ImageUrl { get; set; }
 
         [JsonProperty("mrkdwn_in",NullValueHandling = NullValueHandling.Ignore)]
-        public List<string> MarkdownIn { get; set; } = new List<string>();
+        public List<string> MarkdownIn { get; set; } = new ();
 
         [JsonProperty("pretext",NullValueHandling = NullValueHandling.Ignore)]
         public string Pretext { get; set; }

--- a/Slack.NetStandard/Messages/Blocks/Actions.cs
+++ b/Slack.NetStandard/Messages/Blocks/Actions.cs
@@ -20,6 +20,8 @@ namespace Slack.NetStandard.Messages.Blocks
         public string BlockId { get; set; }
 
         [JsonProperty("elements",NullValueHandling = NullValueHandling.Ignore)]
-        public IList<IMessageElement> Elements { get; set; }
+        public IList<IMessageElement> Elements { get; set; } = new List<IMessageElement>();
+
+        public bool ShouldSerializeElements() => Elements.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Blocks/Context.cs
+++ b/Slack.NetStandard/Messages/Blocks/Context.cs
@@ -16,9 +16,11 @@ namespace Slack.NetStandard.Messages.Blocks
         public string Type => nameof(Context).ToLower();
 
         [JsonProperty("elements", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<IContextElement> Elements { get; set; }
+        public IList<IContextElement> Elements { get; set; } = new List<IContextElement>();
 
         [JsonProperty("block_id", NullValueHandling = NullValueHandling.Ignore)]
         public string BlockId { get; set; }
+
+        public bool ShouldSerializeElements() => Elements.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Blocks/RichText.cs
+++ b/Slack.NetStandard/Messages/Blocks/RichText.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
 using Slack.NetStandard.Messages.Elements;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Blocks
 {
@@ -21,8 +22,10 @@ namespace Slack.NetStandard.Messages.Blocks
         public string BlockId { get; set; }
 
         [JsonProperty("elements", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<IMessageElement> Elements { get; set; }
+        public IList<IMessageElement> Elements { get; set; } = new List<IMessageElement>();
 
         public const string MessageBlockType = "rich_text";
+
+        public bool ShouldSerializeElements() => Elements.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Blocks/Section.cs
+++ b/Slack.NetStandard/Messages/Blocks/Section.cs
@@ -32,9 +32,11 @@ namespace Slack.NetStandard.Messages.Blocks
         public string BlockId { get; set; }
 
         [JsonProperty("fields",NullValueHandling = NullValueHandling.Ignore)]
-        public IList<TextObject> Fields { get; set; }
+        public IList<TextObject> Fields { get; set; } = new List<TextObject>();
 
         [JsonProperty("accessory",NullValueHandling = NullValueHandling.Ignore)]
         public IMessageElement Accessory { get; set; }
+
+        public bool ShouldSerializeFields() => Fields.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/Checkboxes.cs
+++ b/Slack.NetStandard/Messages/Elements/Checkboxes.cs
@@ -21,10 +21,10 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<Option> Options { get; set; }
+        public IList<Option> Options { get; set; } = new List<Option>();
 
         [JsonProperty("initial_options", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<IOption> InitialOptions { get; set; }
+        public IList<IOption> InitialOptions { get; set; } = new List<IOption>();
 
         [JsonProperty("confirm", NullValueHandling = NullValueHandling.Ignore)]
         public Confirmation Confirm { get; set; }
@@ -32,5 +32,7 @@ namespace Slack.NetStandard.Messages.Elements
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
 
+        public bool ShouldSerializeOptions() => Options.Any();
+        public bool ShouldSerializeInitialOptions() => InitialOptions.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/DispatchActionConfig.cs
+++ b/Slack.NetStandard/Messages/Elements/DispatchActionConfig.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Slack.NetStandard.Messages.Elements
@@ -7,12 +9,15 @@ namespace Slack.NetStandard.Messages.Elements
     {
         public DispatchActionConfig(){}
 
-        public DispatchActionConfig(ActionTrigger[] triggers)
+        public DispatchActionConfig(IEnumerable<ActionTrigger> triggers)
         {
-            TriggerActionsOn = triggers;
+            TriggerActionsOn = triggers.ToList();
         }
 
-        [JsonProperty("trigger_actions_on", NullValueHandling = NullValueHandling.Ignore, ItemConverterType = typeof(StringEnumConverter))]
-        public ActionTrigger[] TriggerActionsOn { get; set; }
+        [JsonProperty("trigger_actions_on", NullValueHandling = NullValueHandling.Ignore,
+            ItemConverterType = typeof(StringEnumConverter))]
+        public IList<ActionTrigger> TriggerActionsOn { get; set; } = new List<ActionTrigger>();
+
+        public bool ShouldSerializeTriggerActionsOn() => TriggerActionsOn.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/Filter.cs
+++ b/Slack.NetStandard/Messages/Elements/Filter.cs
@@ -1,11 +1,13 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
     public class Filter
     {
-        [JsonProperty("include",NullValueHandling = NullValueHandling.Ignore)]
-        public string[] Include { get; set; }
+        [JsonProperty("include", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<string> Include { get; set; } = new List<string>();
 
         [JsonProperty("exclude_bot_users",NullValueHandling = NullValueHandling.Ignore)]
         public bool? ExcludeBotUsers { get; set; }
@@ -13,5 +15,6 @@ namespace Slack.NetStandard.Messages.Elements
         [JsonProperty("exclude_external_shared_channels",NullValueHandling = NullValueHandling.Ignore)]
         public bool? ExcludeExternalSharedChannels { get; set; }
 
+        public bool ShouldSerializeInclude() => Include?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/Messages/Elements/MultiChannelsSelect.cs
+++ b/Slack.NetStandard/Messages/Elements/MultiChannelsSelect.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -22,7 +24,7 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("initial_channels", NullValueHandling = NullValueHandling.Ignore)]
-        public string[] InitialChannels { get; set; }
+        public IList<string> InitialChannels { get; set; } = new List<string>();
 
         [JsonProperty("confirm", NullValueHandling = NullValueHandling.Ignore)]
         public Confirmation Confirm { get; set; }
@@ -32,5 +34,7 @@ namespace Slack.NetStandard.Messages.Elements
 
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
+
+        public bool ShouldSerializeInitialChannels() => InitialChannels.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/MultiConversationsSelect.cs
+++ b/Slack.NetStandard/Messages/Elements/MultiConversationsSelect.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -22,7 +24,7 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("initial_conversations", NullValueHandling = NullValueHandling.Ignore)]
-        public string[] InitialConversation { get; set; }
+        public IList<string> InitialConversation { get; set; } = new List<string>();
 
         [JsonProperty("confirm", NullValueHandling = NullValueHandling.Ignore)]
         public Confirmation Confirm { get; set; }
@@ -35,5 +37,7 @@ namespace Slack.NetStandard.Messages.Elements
 
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
+
+        public bool ShouldSerializeInitialConversation() => InitialConversation?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/Messages/Elements/MultiExternalSelect.cs
+++ b/Slack.NetStandard/Messages/Elements/MultiExternalSelect.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -22,7 +24,7 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("initial_options", NullValueHandling = NullValueHandling.Ignore)]
-        public IOption[] InitialOptions { get; set; }
+        public IList<IOption> InitialOptions { get; set; } = new List<IOption>();
 
         [JsonProperty("min_query_length", NullValueHandling = NullValueHandling.Ignore)]
         public int? MinimumQueryLength { get; set; }
@@ -36,5 +38,6 @@ namespace Slack.NetStandard.Messages.Elements
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
 
+        public bool ShouldSerializeInitialOptions() => InitialOptions?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/Messages/Elements/MultiStaticSelect.cs
+++ b/Slack.NetStandard/Messages/Elements/MultiStaticSelect.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -29,15 +30,19 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<Option> Options { get; set; }
+        public IList<Option> Options { get; set; } = new List<Option>();
 
         [JsonProperty("option_groups", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<OptionGroup> OptionGroups { get; set; }
+        public IList<OptionGroup> OptionGroups { get; set; } = new List<OptionGroup>();
 
         [JsonProperty("initial_options", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<IOption> InitialOption { get; set; }
+        public IList<IOption> InitialOption { get; set; } = new List<IOption>();
 
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
+
+        public bool ShouldSerializeOptions() => Options.Any();
+        public bool ShouldSerializeInitialOption() => InitialOption.Any();
+        public bool ShouldSerializeOptionGroups() => OptionGroups.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/MultiUsersSelect.cs
+++ b/Slack.NetStandard/Messages/Elements/MultiUsersSelect.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -22,7 +24,7 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("initial_users", NullValueHandling = NullValueHandling.Ignore)]
-        public string[] InitialUsers { get; set; }
+        public IList<string> InitialUsers { get; set; } = new List<string>();
 
         [JsonProperty("confirm", NullValueHandling = NullValueHandling.Ignore)]
         public Confirmation Confirm { get; set; }
@@ -32,5 +34,7 @@ namespace Slack.NetStandard.Messages.Elements
 
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
+
+        public bool ShouldSerializeInitialUsers() => InitialUsers?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/Messages/Elements/OptionGroup.cs
+++ b/Slack.NetStandard/Messages/Elements/OptionGroup.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -9,6 +10,8 @@ namespace Slack.NetStandard.Messages.Elements
         public PlainText Label { get; set; }
 
         [JsonProperty("options")]
-        public IList<Option> Options { get; set; }
+        public IList<Option> Options { get; set; } = new List<Option>();
+
+        public bool ShouldSerializeOptions() => Options.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/Overflow.cs
+++ b/Slack.NetStandard/Messages/Elements/Overflow.cs
@@ -20,9 +20,11 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("options")]
-        public IList<Option> Options { get; set; }
+        public IList<Option> Options { get; set; } = new List<Option>();
 
         [JsonProperty("confirm", NullValueHandling = NullValueHandling.Ignore)]
         public Confirmation Confirm { get; set; }
+
+        public bool ShouldSerializeOptions() => Options.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/RadioButtons.cs
+++ b/Slack.NetStandard/Messages/Elements/RadioButtons.cs
@@ -21,7 +21,7 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<Option> Options { get; set; }
+        public IList<Option> Options { get; set; } = new List<Option>();
 
         [JsonProperty("initial_option", NullValueHandling = NullValueHandling.Ignore)]
         public IOption InitialOption { get; set; }
@@ -31,5 +31,7 @@ namespace Slack.NetStandard.Messages.Elements
 
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
+
+        public bool ShouldSerializeOptions() => Options.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/RichTextList.cs
+++ b/Slack.NetStandard/Messages/Elements/RichTextList.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
 using Slack.NetStandard.Messages.Elements.RichText;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -12,12 +13,14 @@ namespace Slack.NetStandard.Messages.Elements
         public string Type => ElementType;
 
         [JsonProperty("elements", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<RichTextElement> Elements { get; set; }
+        public IList<RichTextElement> Elements { get; set; } = new List<RichTextElement>();
 
         [JsonProperty("style", NullValueHandling = NullValueHandling.Ignore)]
         public string Style { get; set; }
 
         [JsonProperty("indent", NullValueHandling = NullValueHandling.Ignore)]
         public int? Indent { get; set; }
+
+        public bool ShouldSerializeElements() => Elements.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/RichTextPreformatted.cs
+++ b/Slack.NetStandard/Messages/Elements/RichTextPreformatted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
 using Slack.NetStandard.Messages.Elements.RichText;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -12,6 +13,8 @@ namespace Slack.NetStandard.Messages.Elements
         public string Type => ElementType;
 
         [JsonProperty("elements", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<RichTextElement> Elements { get; set; }
+        public IList<RichTextElement> Elements { get; set; } = new List<RichTextElement>();
+
+        public bool ShouldSerializeElements() => Elements.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/RichTextQuote.cs
+++ b/Slack.NetStandard/Messages/Elements/RichTextQuote.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
 using Slack.NetStandard.Messages.Elements.RichText;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -12,6 +13,8 @@ namespace Slack.NetStandard.Messages.Elements
         public string Type => ElementType;
 
         [JsonProperty("elements", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<RichTextElement> Elements { get; set; }
+        public IList<RichTextElement> Elements { get; set; } = new List<RichTextElement>();
+
+        public bool ShouldSerializeElements() => Elements.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/RichTextSection.cs
+++ b/Slack.NetStandard/Messages/Elements/RichTextSection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
 using Slack.NetStandard.Messages.Elements.RichText;
+using System.Linq;
 
 namespace Slack.NetStandard.Messages.Elements
 {
@@ -12,6 +13,8 @@ namespace Slack.NetStandard.Messages.Elements
         public string Type => ElementType;
 
         [JsonProperty("elements",NullValueHandling = NullValueHandling.Ignore)]
-        public IList<RichTextElement> Elements { get; set; }
+        public IList<RichTextElement> Elements { get; set; } = new List<RichTextElement>();
+
+        public bool ShouldSerializeElements() => Elements.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Elements/StaticSelect.cs
+++ b/Slack.NetStandard/Messages/Elements/StaticSelect.cs
@@ -36,10 +36,10 @@ namespace Slack.NetStandard.Messages.Elements
         public string ActionId { get; set; }
 
         [JsonProperty("options",NullValueHandling = NullValueHandling.Ignore)]
-        public IList<Option> Options { get; set; }
+        public IList<Option> Options { get; set; } = new List<Option>();
 
         [JsonProperty("option_groups",NullValueHandling = NullValueHandling.Ignore)]
-        public IList<OptionGroup> OptionGroups { get; set; }
+        public IList<OptionGroup> OptionGroups { get; set; } = new List<OptionGroup>();
 
         [JsonProperty("initial_option",NullValueHandling = NullValueHandling.Ignore)]
         public IOption InitialOption { get; set; }
@@ -49,5 +49,8 @@ namespace Slack.NetStandard.Messages.Elements
 
         [JsonProperty("focus_on_load", NullValueHandling = NullValueHandling.Ignore)]
         public bool? FocusOnLoad { get; set; }
+
+        public bool ShouldSerializeOptions() => Options.Any();
+        public bool ShouldSerializeOptionGroups() => OptionGroups.Any();
     }
 }

--- a/Slack.NetStandard/Messages/Message.cs
+++ b/Slack.NetStandard/Messages/Message.cs
@@ -47,16 +47,16 @@ namespace Slack.NetStandard.Messages
         [JsonProperty("is_starred", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsStarred { get; set; }
 
-        [JsonProperty("pinned_to", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("pinned_to", NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public string[] PinnedTo { get; set; }
 
-        [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public Reaction[] Reactions { get; set; }
 
         [JsonProperty("reply_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? ReplyCount { get; set; }
 
-        [JsonProperty("reply_users",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("reply_users",NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public string[] ReplyUsers { get; set; }
 
         [JsonProperty("reply_users_count",NullValueHandling = NullValueHandling.Ignore)]
@@ -77,13 +77,14 @@ namespace Slack.NetStandard.Messages
         [JsonProperty("icons", NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, string> Icons { get; set; }
 
-        [JsonProperty("files",NullValueHandling = NullValueHandling.Ignore)]
-        public File[] Files { get; set; }
+        [JsonProperty("files", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<File> Files { get; set; } = new List<File>();
 
         [JsonExtensionData]
         public Dictionary<string,object> OtherFields { get; set; }
 
         public bool ShouldSerializeBlocks() => Blocks?.Any() ?? false;
         public bool ShouldSerializeAttachments() => Attachments?.Any() ?? false;
+        public bool ShouldSerializeFiles() => Files?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/Objects/Acceptance.cs
+++ b/Slack.NetStandard/Objects/Acceptance.cs
@@ -23,7 +23,7 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("accepting_user",NullValueHandling = NullValueHandling.Ignore)]
         public User AcceptingUser { get; set; }
 
-        [JsonProperty("reviews",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("reviews",NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public Review[] Reviews { get; set; }
 
         [JsonExtensionData]

--- a/Slack.NetStandard/Objects/Channel.cs
+++ b/Slack.NetStandard/Objects/Channel.cs
@@ -55,7 +55,7 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("is_org_shared", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsOrgShared { get; set; }
 
-        [JsonProperty("pending_shared", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("pending_shared", NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public string[] PendingShared { get; set; }
 
         [JsonProperty("is_pending_ext_shared", NullValueHandling = NullValueHandling.Ignore)]
@@ -88,7 +88,7 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("purpose", NullValueHandling = NullValueHandling.Ignore)]
         public ChannelValue Purpose { get; set; }
 
-        [JsonProperty("previous_names", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("previous_names", NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public string[] PreviousNames { get; set; }
 
         [JsonProperty("priority", NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Objects/ElementValue.cs
+++ b/Slack.NetStandard/Objects/ElementValue.cs
@@ -4,6 +4,7 @@ using Slack.NetStandard.Messages.Elements;
 
 namespace Slack.NetStandard.Objects
 {
+    [AcceptedArray]
     public class ElementValue
     {
         [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Objects/File.cs
+++ b/Slack.NetStandard/Objects/File.cs
@@ -112,7 +112,7 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("shares",NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string,Dictionary<string,Share[]>> Shares { get; set; }
 
-        [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public Reaction[] Reactions { get; set; }
     }
 }

--- a/Slack.NetStandard/Objects/Invite.cs
+++ b/Slack.NetStandard/Objects/Invite.cs
@@ -32,7 +32,7 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("recipient_user_id", NullValueHandling = NullValueHandling.Ignore)]
         public string RecipientUserId { get; set; }
 
-        [JsonProperty("acceptances",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("acceptances",NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public Acceptance[] Acceptances { get; set; }
 
         [JsonExtensionData]

--- a/Slack.NetStandard/Objects/Share.cs
+++ b/Slack.NetStandard/Objects/Share.cs
@@ -4,7 +4,7 @@ namespace Slack.NetStandard.Objects
 {
     public class Share
     {
-        [JsonProperty("reply_users",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("reply_users",NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public string[] ReplyUsers { get; set; }
 
         [JsonProperty("reply_count",NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Objects/Team.cs
+++ b/Slack.NetStandard/Objects/Team.cs
@@ -22,7 +22,7 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("enterprise_name", NullValueHandling = NullValueHandling.Ignore)]
         public string EnterpriseName { get; set; }
 
-        [JsonProperty("default_channels", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("default_channels", NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public string[] DefaultChannels { get; set; }
 
         [JsonProperty("date_created", NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Objects/Usergroup.cs
+++ b/Slack.NetStandard/Objects/Usergroup.cs
@@ -46,7 +46,7 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("prefs",NullValueHandling = NullValueHandling.Ignore)]
         public UsergroupPreferences Prefs { get; set; }
 
-        [JsonProperty("users",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("users",NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public string[] Users { get; set; }
 
         [JsonProperty("user_count",NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/Objects/UsergroupPreferences.cs
+++ b/Slack.NetStandard/Objects/UsergroupPreferences.cs
@@ -4,10 +4,10 @@ namespace Slack.NetStandard.Objects
 {
     public class UsergroupPreferences
     {
-        [JsonProperty("channels",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("channels",NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public string[] Channels { get; set; }
 
-        [JsonProperty("groups",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("groups",NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public string[] Groups { get; set; }
     }
 }

--- a/Slack.NetStandard/Objects/View.cs
+++ b/Slack.NetStandard/Objects/View.cs
@@ -32,8 +32,8 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("submit", NullValueHandling = NullValueHandling.Ignore)]
         public PlainText Submit { get; set; }
 
-        [JsonProperty("blocks",NullValueHandling = NullValueHandling.Ignore)]
-        public IMessageBlock[] Blocks { get; set; }
+        [JsonProperty("blocks", NullValueHandling = NullValueHandling.Ignore)]
+        public List<IMessageBlock> Blocks { get; set; } = new ();
 
         [JsonProperty("clear_on_close",NullValueHandling = NullValueHandling.Ignore)]
         public bool? ClearOnClose { get; set; }

--- a/Slack.NetStandard/Objects/View.cs
+++ b/Slack.NetStandard/Objects/View.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Slack.NetStandard.Messages;
 using Slack.NetStandard.Messages.Blocks;
@@ -33,7 +34,7 @@ namespace Slack.NetStandard.Objects
         public PlainText Submit { get; set; }
 
         [JsonProperty("blocks", NullValueHandling = NullValueHandling.Ignore)]
-        public List<IMessageBlock> Blocks { get; set; } = new ();
+        public List<IMessageBlock> Blocks { get; set; } = new();
 
         [JsonProperty("clear_on_close",NullValueHandling = NullValueHandling.Ignore)]
         public bool? ClearOnClose { get; set; }
@@ -65,5 +66,6 @@ namespace Slack.NetStandard.Objects
         [JsonExtensionData]
         public Dictionary<string, object> OtherFields { get; set; }
 
+        public bool ShouldSerializeBlocks() => Blocks.Any();
     }
 }

--- a/Slack.NetStandard/Objects/WorkflowStep.cs
+++ b/Slack.NetStandard/Objects/WorkflowStep.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.Objects
 {
@@ -31,7 +32,9 @@ namespace Slack.NetStandard.Objects
         [JsonProperty("inputs",NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, WorkflowInput> Inputs { get; set; }
 
-        [JsonProperty("outputs",NullValueHandling = NullValueHandling.Ignore)]
-        public WorkflowOutput[] Outputs { get; set; }
+        [JsonProperty("outputs", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<WorkflowOutput> Outputs { get; set; } = new List<WorkflowOutput>();
+
+        public bool ShouldSerializeOutputs() => Outputs?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/Slack.NetStandard.csproj
+++ b/Slack.NetStandard/Slack.NetStandard.csproj
@@ -16,6 +16,14 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\LICENSE">
       <Pack>True</Pack>

--- a/Slack.NetStandard/Slack.NetStandard.csproj
+++ b/Slack.NetStandard/Slack.NetStandard.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.13.4</Version>
+    <Version>4.0.0</Version>
     <Description>.NET Core package that helps with Slack interactions, events and web API</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReleaseNotes>Fix bug where Authorization not being set correctly</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated properties to use Lists wherever it's involved in making a request</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
     <Authors>Steven Pears</Authors>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <ProjectReference Include="..\Slack.NetStandard.Analyzers\Slack.NetStandard.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/Slack.NetStandard/WebApi/Admin/EmojiCategory.cs
+++ b/Slack.NetStandard/WebApi/Admin/EmojiCategory.cs
@@ -7,7 +7,7 @@ namespace Slack.NetStandard.WebApi.Admin
         [JsonProperty("name",NullValueHandling = NullValueHandling.Ignore)]
         public string Name { get; set; }
 
-        [JsonProperty("emoji_names", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("emoji_names", NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public string[] EmojiNames { get; set; }
     }
 }

--- a/Slack.NetStandard/WebApi/Admin/ResolvedApp.cs
+++ b/Slack.NetStandard/WebApi/Admin/ResolvedApp.cs
@@ -8,7 +8,7 @@ namespace Slack.NetStandard.WebApi.Admin
         [JsonProperty("app")]
         public App App { get; set; }
 
-        [JsonProperty("scopes", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("scopes", NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public Scope[] Scopes { get; set; }
 
         [JsonProperty("date_updated", NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/WebApi/Admin/SetTeamsRequest.cs
+++ b/Slack.NetStandard/WebApi/Admin/SetTeamsRequest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.WebApi.Admin
 {
@@ -13,10 +14,12 @@ namespace Slack.NetStandard.WebApi.Admin
         [JsonProperty("org_channel",NullValueHandling = NullValueHandling.Ignore)]
         public bool? OrgChannel { get; set; }
 
-        [JsonProperty("target_team_ids",NullValueHandling = NullValueHandling.Ignore)]
-        public string[] TargetTeams { get; set; }
+        [JsonProperty("target_team_ids", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<string> TargetTeams { get; set; } = new List<string>();
 
         [JsonProperty("team_id",NullValueHandling = NullValueHandling.Ignore)]
         public string Team { get; set; }
+
+        public bool ShouldSerializeTargetTeams() => TargetTeams?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/WebApi/Chat/UnfurlRequest.cs
+++ b/Slack.NetStandard/WebApi/Chat/UnfurlRequest.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Newtonsoft.Json;
 using Slack.NetStandard.Messages;
 using Slack.NetStandard.Messages.Blocks;
+using System.Linq;
 
 namespace Slack.NetStandard.WebApi.Chat
 {
@@ -18,8 +19,8 @@ namespace Slack.NetStandard.WebApi.Chat
         [JsonProperty("unfurls")]
         public Dictionary<string,Attachment> Unfurls { get; set; }
 
-        [JsonProperty("user_auth_blocks",NullValueHandling = NullValueHandling.Ignore)]
-        public IMessageBlock[] UserAuthBlocks { get; set; }
+        [JsonProperty("user_auth_blocks", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<IMessageBlock> UserAuthBlocks { get; set; } = new List<IMessageBlock>();
 
         [JsonProperty("user_auth_message",NullValueHandling = NullValueHandling.Ignore)]
         public string UserAuthMessage { get; set; }
@@ -29,5 +30,7 @@ namespace Slack.NetStandard.WebApi.Chat
 
         [JsonProperty("user_auth_url",NullValueHandling = NullValueHandling.Ignore)]
         public string UserAuthUrl { get; set; }
+
+        public bool ShouldSerializeUserAuthBlocks() => UserAuthBlocks?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/WebApi/Chat/UpdateMessageRequest.cs
+++ b/Slack.NetStandard/WebApi/Chat/UpdateMessageRequest.cs
@@ -28,7 +28,7 @@ namespace Slack.NetStandard.WebApi.Chat
         public bool? LinkNames { get; set; }
 
         [JsonProperty("file_ids", NullValueHandling = NullValueHandling.Ignore)]
-        public string[] FileIds { get; set; }
+        public IList<string> FileIds { get; set; } = new List<string>();
 
         [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
         public IList<Attachment> Attachments { get; set; } = new List<Attachment>();
@@ -39,5 +39,6 @@ namespace Slack.NetStandard.WebApi.Chat
 
         public bool ShouldSerializeBlocks() => Blocks?.Any() ?? false;
         public bool ShouldSerializeAttachments() => Attachments?.Any() ?? false;
+        public bool ShouldSerializeFileIds() => FileIds?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/WebApi/Conversations/CreateConversationRequest.cs
+++ b/Slack.NetStandard/WebApi/Conversations/CreateConversationRequest.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.WebApi.Conversations
 {
@@ -10,7 +12,9 @@ namespace Slack.NetStandard.WebApi.Conversations
         [JsonProperty("is_private",NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsPrivate { get; set; }
 
-        [JsonProperty("user_ids",NullValueHandling = NullValueHandling.Ignore)]
-        public string[] UserIds { get; set; }
+        [JsonProperty("user_ids", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<string> UserIds { get; set; } = new List<string>();
+
+        public bool ShouldSerializeUserIds() => UserIds?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/WebApi/Conversations/InviteSharedRequest.cs
+++ b/Slack.NetStandard/WebApi/Conversations/InviteSharedRequest.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.Linq;
 
 namespace Slack.NetStandard.WebApi.Conversations
 {
@@ -8,10 +10,10 @@ namespace Slack.NetStandard.WebApi.Conversations
         public string Channel { get; set; }
 
         [JsonProperty("user_ids", NullValueHandling = NullValueHandling.Ignore)]
-        public string[] UserIds { get; set; }
+        public IList<string> UserIds { get; set; } = new List<string>();
 
         [JsonProperty("emails", NullValueHandling = NullValueHandling.Ignore)]
-        public string[] Emails { get; set; }
+        public IList<string> Emails { get; set; } = new List<string>();
 
         [JsonProperty("external_limited", NullValueHandling = NullValueHandling.Ignore)]
         public bool? ExternalLimited { get; set; }
@@ -21,5 +23,8 @@ namespace Slack.NetStandard.WebApi.Conversations
 
         [JsonProperty("tracking_id", NullValueHandling = NullValueHandling.Ignore)]
         public string TrackingId { get; set; }
+
+        public bool ShouldSerializeUserIds() => UserIds?.Any() ?? false;
+        public bool ShouldSerializeEmails() => Emails?.Any() ?? false;
     }
 }

--- a/Slack.NetStandard/WebApi/Search/PagedData.cs
+++ b/Slack.NetStandard/WebApi/Search/PagedData.cs
@@ -4,7 +4,7 @@ namespace Slack.NetStandard.WebApi.Search
 {
     public class PagedData<T>
     {
-        [JsonProperty("matches",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("matches",NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public T[] Matches { get; set; }
 
         [JsonProperty("paging",NullValueHandling = NullValueHandling.Ignore)]

--- a/Slack.NetStandard/WebApi/Teams/TeamProfile.cs
+++ b/Slack.NetStandard/WebApi/Teams/TeamProfile.cs
@@ -4,7 +4,7 @@ namespace Slack.NetStandard.WebApi.Teams
 {
     public class TeamProfile
     {
-        [JsonProperty("fields",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("fields",NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
         public TeamProfileField[] Fields { get; set; }
     }
 }

--- a/Slack.NetStandard/WebApi/Teams/TeamProfileField.cs
+++ b/Slack.NetStandard/WebApi/Teams/TeamProfileField.cs
@@ -20,7 +20,7 @@ namespace Slack.NetStandard.WebApi.Teams
         [JsonProperty("type",NullValueHandling = NullValueHandling.Ignore)]
         public string Type { get; set; }
 
-        [JsonProperty("possible_values",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("possible_values",NullValueHandling = NullValueHandling.Ignore),AcceptedArray]
         public string[] PossibleValues { get; set; }
 
         [JsonProperty("options",NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
V4 ensures that wherever a collection is required for creating/requesting information from Slack - it uses a List property rather than the previous Array usage.

Lists are always new'ed up as part of construction, and a ShouldSerialize method has been added for every property to ensure that  they're not included in the request if they're empty (could have used a JSON.Net contract but that meant breaking all existing implementations where serialization was being used outside of the client such as sending via a response URL)

New Roslyn Analyzers added to the project to ensure future changes don't revert these rules.