### PR TITLE
Feature/multiselectoption

### DIFF
--- a/Slack.NetStandard/Messages/Elements/MultiConversationsSelect.cs
+++ b/Slack.NetStandard/Messages/Elements/MultiConversationsSelect.cs
@@ -26,6 +26,9 @@ namespace Slack.NetStandard.Messages.Elements
         [JsonProperty("initial_conversations", NullValueHandling = NullValueHandling.Ignore)]
         public IList<string> InitialConversation { get; set; } = new List<string>();
 
+        [JsonProperty("default_to_current_conversation", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? DefaultToCurrentConversation { get; set; }
+
         [JsonProperty("confirm", NullValueHandling = NullValueHandling.Ignore)]
         public Confirmation Confirm { get; set; }
 

--- a/Slack.NetStandard/Slack.NetStandard.csproj
+++ b/Slack.NetStandard/Slack.NetStandard.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>8.1.0</Version>
+    <Version>8.1.1</Version>
     <Description>.NET Core package that helps with Slack interactions, events and web API</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReleaseNotes>
-        Added support for Rich Text Input element
+    v8.1.1 Add support for "default_to_current_conversation" in multi select conversation
+    v8.1.0 Added support for Rich Text Input element
     </PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Add `default_to_current_conversation` to the multi conversations select.

[Slack API Doc](https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select) 

Thx for your work !