### PR TITLE
Fix property name in usergroup enable/disable request

### DIFF
--- a/Slack.NetStandard.Tests/WebApiTests_Usergroups.cs
+++ b/Slack.NetStandard.Tests/WebApiTests_Usergroups.cs
@@ -27,7 +27,7 @@ namespace Slack.NetStandard.Tests
             await Utility.AssertEncodedWebApi(
                 c => c.Usergroups.Disable(new UsergroupDisableRequest
                 {
-                    Name = "S060", IncludeCount = true, TeamId = "T12345"
+                    Usergroup = "S060", IncludeCount = true, TeamId = "T12345"
                 }), "usergroups.disable", "Web_UsergroupResponse.json", nvc =>
                 {
                     Assert.Equal("S060", nvc["usergroup"]);
@@ -42,7 +42,7 @@ namespace Slack.NetStandard.Tests
             await Utility.AssertEncodedWebApi(
                 c => c.Usergroups.Enable(new UsergroupEnableRequest
                 {
-                    Name = "S060", IncludeCount = true, TeamId = "T12345"
+                    Usergroup = "S060", IncludeCount = true, TeamId = "T12345"
                 }), "usergroups.enable", "Web_UsergroupResponse.json", nvc =>
                 {
                     Assert.Equal("S060", nvc["usergroup"]);

--- a/Slack.NetStandard/WebApi/Usergroups/UsergroupDisableRequest.cs
+++ b/Slack.NetStandard/WebApi/Usergroups/UsergroupDisableRequest.cs
@@ -5,7 +5,7 @@ namespace Slack.NetStandard.WebApi.Usergroups;
 public class UsergroupDisableRequest
 {
     [JsonProperty("usergroup")]
-    public string Name { get; set; }
+    public string Usergroup { get; set; }
 
     [JsonProperty("include_count",NullValueHandling = NullValueHandling.Ignore)]
     public bool? IncludeCount { get; set; }

--- a/Slack.NetStandard/WebApi/Usergroups/UsergroupEnableRequest.cs
+++ b/Slack.NetStandard/WebApi/Usergroups/UsergroupEnableRequest.cs
@@ -5,7 +5,7 @@ namespace Slack.NetStandard.WebApi.Usergroups
     public class UsergroupEnableRequest
     {
         [JsonProperty("usergroup")]
-        public string Name { get; set; }
+        public string Usergroup { get; set; }
 
         [JsonProperty("include_count",NullValueHandling = NullValueHandling.Ignore)]
         public bool? IncludeCount { get; set; }


### PR DESCRIPTION
This PR will fix the name of the key property in the `UsergroupEnableRequest` and `UsergroupDisableRequest` request objects.