### PR TITLE
Extend auth.teams.list with icon support

### DIFF
--- a/Slack.NetStandard.Tests/Examples/Web_AuthTeamsList.json
+++ b/Slack.NetStandard.Tests/Examples/Web_AuthTeamsList.json
@@ -3,11 +3,31 @@
   "teams": [
     {
       "name": "Shinichi's workspace",
-      "id": "T12345678"
+      "id": "T12345678",
+      "icon": {
+        "image_default": "true",
+        "image_34": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-34.png",
+        "image_44": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-44.png",
+        "image_68": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-68.png",
+        "image_88": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-88.png",
+        "image_102": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-102.png",
+        "image_230": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-230.png",
+        "image_132": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-132.png"
+      }
     },
     {
       "name": "Migi's workspace",
-      "id": "T12345679"
+      "id": "T12345679",
+      "icon": {
+        "image_default": "true",
+        "image_34": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-34.png",
+        "image_44": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-44.png",
+        "image_68": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-68.png",
+        "image_88": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-88.png",
+        "image_102": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-102.png",
+        "image_230": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-230.png",
+        "image_132": "https://a.slack-edge.com/80588/img/avatars-teams/ava_0009-132.png"
+      }
     }
   ],
   "response_metadata": {

--- a/Slack.NetStandard.Tests/WebApiTests_Auth.cs
+++ b/Slack.NetStandard.Tests/WebApiTests_Auth.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Slack.NetStandard.Tests
@@ -30,7 +31,9 @@ namespace Slack.NetStandard.Tests
                     Assert.True(jo.Value<bool>("include_icon"));
                     jo.TestPaging("C123",5);
                 });
+            
             Assert.Equal(2,response.Teams.Length);
+            Assert.True(response.Teams[0].Icon.Count > 0);
         }
     }
 }

--- a/Slack.NetStandard/WebApi/Auth/BasicTeamData.cs
+++ b/Slack.NetStandard/WebApi/Auth/BasicTeamData.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Slack.NetStandard.WebApi.Auth;
+
+public class BasicTeamData : SlackId
+{
+    [JsonProperty("icon", NullValueHandling = NullValueHandling.Ignore)]
+    public Dictionary<string, string> Icon { get; set; }
+}

--- a/Slack.NetStandard/WebApi/Auth/TeamsListResponse.cs
+++ b/Slack.NetStandard/WebApi/Auth/TeamsListResponse.cs
@@ -4,6 +4,6 @@ namespace Slack.NetStandard.WebApi.Auth;
 
 public class TeamsListResponse : WebApiResponse<ResponseMetadataCursor>
 {
-    [JsonProperty("teams",NullValueHandling = NullValueHandling.Ignore)]
-    public SlackId[] Teams { get; set; }
+    [JsonProperty("teams", NullValueHandling = NullValueHandling.Ignore)]
+    public BasicTeamData[] Teams { get; set; }
 }


### PR DESCRIPTION
This PR will extend the response of auth.teams.list to include team icons.