### PR TITLE
Add enterprise user object to user.info response

### DIFF
--- a/Slack.NetStandard.Tests/Examples/Web_UsersInfo.json
+++ b/Slack.NetStandard.Tests/Examples/Web_UsersInfo.json
@@ -36,6 +36,21 @@
     "is_bot": false,
     "updated": 1502138686,
     "is_app_user": false,
-    "has_2fa": false
+    "has_2fa": false,
+    "is_email_confirmed": true,
+    "locale": "en",
+    "who_can_share_contact_card": "EVERYONE",
+    "enterprise_user": {
+      "id": "U123ABC456",
+      "enterprise_id": "E123ABC456",
+      "enterprise_name": "Sherlock Holmes Detective Agency",
+      "is_admin": false,
+      "is_owner": false,
+      "is_primary_owner": false,
+      "teams": [
+        "T123ABC456",
+        "T789DEF000"
+      ]
+    }
   }
 }

--- a/Slack.NetStandard/Objects/EnterpriseUser.cs
+++ b/Slack.NetStandard/Objects/EnterpriseUser.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+
+namespace Slack.NetStandard.Objects;
+
+public class EnterpriseUser
+{
+    [JsonProperty("id")]
+    public string ID { get; set; }
+
+    [JsonProperty("enterprise_id", NullValueHandling = NullValueHandling.Ignore)]
+    public string EnterpriseId { get; set; }
+
+    [JsonProperty("enterprise_name", NullValueHandling = NullValueHandling.Ignore)]
+    public string EnterpriseName { get; set; }
+
+    [JsonProperty("is_admin", NullValueHandling = NullValueHandling.Ignore)]
+    public bool? IsAdmin { get; set; }
+
+    [JsonProperty("is_owner", NullValueHandling = NullValueHandling.Ignore)]
+    public bool? IsOwner { get; set; }
+
+    [JsonProperty("is_primary_owner", NullValueHandling = NullValueHandling.Ignore)]
+    public bool? IsPrimaryOwner { get; set; }
+
+    [JsonProperty("teams", NullValueHandling = NullValueHandling.Ignore), AcceptedArray]
+    public string[] Teams { get; set; }
+}

--- a/Slack.NetStandard/Objects/User.cs
+++ b/Slack.NetStandard/Objects/User.cs
@@ -1,73 +1,76 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Slack.NetStandard.Objects
 {
-    public class User:SlackId
+    public class User : SlackId
     {
-        [JsonProperty("team_id",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("team_id", NullValueHandling = NullValueHandling.Ignore)]
         public string Team { get; set; }
 
-        [JsonProperty("deleted",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
-        [JsonProperty("color",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("color", NullValueHandling = NullValueHandling.Ignore)]
         public string Color { get; set; }
 
-        [JsonProperty("real_name",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("real_name", NullValueHandling = NullValueHandling.Ignore)]
         public string RealName { get; set; }
 
-        [JsonProperty("tz",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("tz", NullValueHandling = NullValueHandling.Ignore)]
         public string TimeZone { get; set; }
 
-        [JsonProperty("tz_label",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("tz_label", NullValueHandling = NullValueHandling.Ignore)]
         public string TimezoneLabel { get; set; }
 
-        [JsonProperty("tz_offset",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("tz_offset", NullValueHandling = NullValueHandling.Ignore)]
         public long? TimezoneOffset { get; set; }
 
-        [JsonProperty("profile",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("profile", NullValueHandling = NullValueHandling.Ignore)]
         public UserProfile Profile { get; set; }
 
-        [JsonProperty("is_admin",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("is_admin", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsAdmin { get; set; }
 
-        [JsonProperty("is_owner",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("is_owner", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsOwner { get; set; }
 
-        [JsonProperty("is_primary_owner",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("is_primary_owner", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsPrimaryOwner { get; set; }
 
-        [JsonProperty("is_restricted",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("is_restricted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsRestricted { get; set; }
 
         [JsonProperty("is_ultra_restricted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsUltraRestricted { get; set; }
 
-        [JsonProperty("is_bot",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("is_bot", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsBot { get; set; }
 
-        [JsonProperty("is_stranger",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("is_stranger", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsStranger { get; set; }
 
-        [JsonProperty("updated",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("updated", NullValueHandling = NullValueHandling.Ignore)]
         public long? Updated { get; set; }
 
-        [JsonProperty("is_app_user",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("is_app_user", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsAppUser { get; set; }
 
-        [JsonProperty("is_invited_user",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("is_invited_user", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsInvitedUser { get; set; }
 
         [JsonProperty("is_email_confirmed", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsEmailConfirmed { get; set; }
+        
+        [JsonProperty("who_can_share_contact_card", NullValueHandling = NullValueHandling.Ignore)]
+        public string WhoCanShareContactCard { get; set; }
 
-        [JsonProperty("has_2fa",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("has_2fa", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Has2FA { get; set; }
 
-        [JsonProperty("locale",NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("locale", NullValueHandling = NullValueHandling.Ignore)]
         public string Locale { get; set; }
+        
+        [JsonProperty("enterprise_user", NullValueHandling = NullValueHandling.Ignore)]
+        public EnterpriseUser EnterpriseUser { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the EnterpriseUser object to the user.info API response as depicted [here](https://api.slack.com/types/user).