### PR TITLE
Change Option text and description to text object

### DIFF
--- a/Slack.NetStandard/Messages/Elements/Option.cs
+++ b/Slack.NetStandard/Messages/Elements/Option.cs
@@ -7,7 +7,7 @@ namespace Slack.NetStandard.Messages.Elements
     public class Option:IOption
     {
         [JsonProperty("text")]
-        public PlainText Text { get; set; }
+        public TextObject Text { get; set; }
 
         [JsonProperty("value")]
         public string Value { get; set; }
@@ -16,6 +16,6 @@ namespace Slack.NetStandard.Messages.Elements
         public string Url { get; set; }
 
         [JsonProperty("description",NullValueHandling = NullValueHandling.Ignore)]
-        public PlainText Description { get; set; }
+        public TextObject Description { get; set; }
     }
 }


### PR DESCRIPTION
According slack api [doc](https://api.slack.com/reference/block-kit/composition-objects#option), the option `text` is _text object_ and `description` support _mrkdwn_ formatting if element is checkbox group or radio buttons group.  So suggest to change the property type to TextObject.