### PR TITLE
Add RateLimited extension method for Slack API

### DIFF
--- a/Slack.NetStandard.Tests/RetryTests.cs
+++ b/Slack.NetStandard.Tests/RetryTests.cs
@@ -1,0 +1,69 @@
+﻿using Slack.NetStandard.WebApi;
+using System.Net.Http;
+using Xunit;
+using System.Threading.Tasks;
+using System;
+
+namespace Slack.NetStandard.Tests
+{
+    public class RetryTests
+    {
+        [Fact]
+        public async Task RetryShortCircuitsOnSuccessfulResponse()
+        {
+            var response = new WebApiResponse();
+            response.OK = true;
+
+            var http = new HttpClient(new ActionHandler(req => Task.FromResult(response)));
+            var client = new SlackWebApiClient(http);
+            var called = 0;
+
+            await client.RateLimited(c => { called++; return Task.FromResult(response); }, 1);
+            Assert.Equal(1, called);
+        }
+
+        [Fact]
+        public async Task RetryShortCircuitsOnFailedResponseWithoutRetry()
+        {
+            var response = new WebApiResponse();
+            response.OK = false;
+
+            var http = new HttpClient(new ActionHandler(req => Task.FromResult(response)));
+            var client = new SlackWebApiClient(http);
+            var called = 0;
+
+            await client.RateLimited(c => { called++; return Task.FromResult(response); }, 1);
+            Assert.Equal(1, called);
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(3, 3)]
+        [InlineData(5, 5)]
+        public async Task RetryReturnsFailedResponseAfterMaxAttempts(int attempts, int expected)
+        {
+            var response = new WebApiResponse();
+            response.OK = false;
+            response.RetryAfter = TimeSpan.FromSeconds(1);
+
+            var http = new HttpClient(new ActionHandler(req => Task.CompletedTask));
+            var client = new SlackWebApiClient(http);
+            var called = 0;
+
+            await TakesAtLeast(client.RateLimited(c => { called++; return Task.FromResult(response); }, attempts),TimeSpan.FromSeconds(attempts));
+            Assert.Equal(expected, called);
+        }
+
+        private async Task TakesAtLeast(Task method, TimeSpan minDuration)
+        {
+            var result = await Task.WhenAny(method, Task.Delay(minDuration));
+            if(result == method)
+            {
+                throw new InvalidOperationException("Method completed before minimum duration");
+            }
+        }
+
+
+
+    }
+}

--- a/Slack.NetStandard/RetryExtension.cs
+++ b/Slack.NetStandard/RetryExtension.cs
@@ -1,0 +1,28 @@
+﻿using Slack.NetStandard.WebApi;
+using System;
+using System.Threading.Tasks;
+
+namespace Slack.NetStandard
+{
+    public static class RetryExtension
+    {
+        public static async Task<T> RateLimited<T>(this ISlackApiClient api, Func<ISlackApiClient, Task<T>> action, int maxRetries = 3) where T:WebApiResponseBase
+        {
+            var attempts = 0;
+            var lastResponse = default(T);
+
+            while(++attempts <= maxRetries)
+            {
+                var response = await action(api);
+                if (response.OK || !response.RetryAfter.HasValue)
+                {
+                    return response;
+                }
+                lastResponse = response;
+                await Task.Delay(response.RetryAfter.Value);
+            }
+
+            return lastResponse;
+        }
+    }
+}

--- a/Slack.NetStandard/Slack.NetStandard.csproj
+++ b/Slack.NetStandard/Slack.NetStandard.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>9.7.0</Version>
+    <Version>9.7.1</Version>
     <Description>.NET Core package that helps with Slack interactions, events and web API</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReleaseNotes>
 		Update View to support notify_on_close
+		Add ISlackApiClent.RateLimited to automatically handle and retry failed requests with a Retry-After header
 	</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Add an extension method that makes an original call, and then if the call fails (OK==false) with a RetryAfter header available, it retries X number of times where the default for X is 3