### PR TITLE
Introduce GET calls on Slack API

### DIFF
--- a/Slack.NetStandard.Tests/WebApiTests_Files.cs
+++ b/Slack.NetStandard.Tests/WebApiTests_Files.cs
@@ -155,18 +155,20 @@ namespace Slack.NetStandard.Tests
         [Fact]
         public async Task FilesRemote_GetExternal()
         {
-            await Utility.AssertWebApi(c => c.Files.GetExternalUploadUrl(new GetExternalUploadUrlRequest("test.jpg",123)
-                {
-                    AltTxt = "alt",
-                    SnippetType = "test"
-                }), "files.getUploadURLExternal",
-                "Web_FilesGetExternal.json", jo =>
-                {
-                    Assert.Equal("test", jo.Value<string>("snippet_type"));
-                    Assert.Equal("alt", jo.Value<string>("alt_txt"));
-                    Assert.Equal("test.jpg", jo.Value<string>("filename"));
-                    Assert.Equal(123, jo.Value<int>("length"));
-                });
+            var request = new GetExternalUploadUrlRequest("test.jpg", 123)
+            {
+                AltTxt = "alt",
+                SnippetType = "test"
+            };
+            await Utility.CheckApiGet(c => c.Files.GetExternalUploadUrl(request), $"files.getUploadURLExternal",
+                 jo =>
+                 {
+                     Assert.Equal("test", jo.Value<string>("snippet_type"));
+                     Assert.Equal("alt", jo.Value<string>("alt_txt"));
+                     Assert.Equal("test.jpg", jo.Value<string>("filename"));
+                     Assert.Equal(123, jo.Value<int>("length"));
+                 },
+                Utility.ExampleFileContent<GetExternalUploadUrlResponse>("Web_FilesGetExternal.json"));
         }
 
         [Fact]

--- a/Slack.NetStandard/IWebApiClient.cs
+++ b/Slack.NetStandard/IWebApiClient.cs
@@ -9,6 +9,7 @@ namespace Slack.NetStandard
     {
         Task<WebApiResponse> MakeJsonCall<TRequest>(string methodName, TRequest request);
         Task<TResponse> MakeJsonCall<TRequest, TResponse>(string methodName, TRequest request) where TResponse : WebApiResponseBase;
+        Task<TResponse> MakeGetCall<TRequest, TResponse>(string methodName, TRequest request) where TResponse : WebApiResponseBase;
         Task<WebApiResponse> MakeUrlEncodedCall(string methodName, Dictionary<string, string> dictionary = null);
         Task<HttpResponseMessage> MakeRawUrlEncodedCall(string methodName, Dictionary<string, string> dictionary = null);
         Task<T> MakeUrlEncodedCall<T>(string methodName, Dictionary<string, string> dictionary = null) where T:WebApiResponseBase;

--- a/Slack.NetStandard/WebApi/FilesApi.cs
+++ b/Slack.NetStandard/WebApi/FilesApi.cs
@@ -52,7 +52,7 @@ namespace Slack.NetStandard.WebApi
 
         public Task<GetExternalUploadUrlResponse> GetExternalUploadUrl(GetExternalUploadUrlRequest request)
         {
-            return _client.MakeJsonCall<GetExternalUploadUrlRequest, GetExternalUploadUrlResponse>(
+            return _client.MakeGetCall<GetExternalUploadUrlRequest, GetExternalUploadUrlResponse>(
                 "files.getUploadURLExternal", request);
         }
 


### PR DESCRIPTION
Introduce GET calls on Slack API to handle nicely files.getUploadURLExternal method which is most likely the UNIQUE api method with a GET in Slack API.

![image](https://github.com/user-attachments/assets/dae17068-c81c-4237-9671-6fd5ee6f84eb)

I'm not really confident about naming around new method in IWebApiClient, as much as i'm not really satisfied with the "Request to QueryPath" method but this makes the job (and the tests are green).

I also hesited to create the "GET" pending for "AssertWebApi" rather than "CheckApiGet" (here again, naming is not ideal :-p)

